### PR TITLE
Build gateway add-on image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: build-addon
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          tags: |
+            ghcr.io/d3vi1/helianthus-ha-addon:latest
+            ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}
+          build-args: |
+            EBUSGATEWAY_VERSION=main
+          secrets: |
+            github_token=${{ secrets.PRIVATE_REPO_READ_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,26 @@
+# syntax=docker/dockerfile:1.6
+
 ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19
+
+FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+ARG TARGETVARIANT=
+ARG EBUSGATEWAY_VERSION=main
+
+RUN apk add --no-cache git ca-certificates
+
+ENV CGO_ENABLED=0
+ENV GOPRIVATE=github.com/d3vi1/*
+
+RUN --mount=type=secret,id=github_token \
+    if [ -f /run/secrets/github_token ]; then \
+      git config --global url."https://$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \
+    fi \
+ && GOBIN=/out GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
+    go install github.com/d3vi1/helianthus-ebusgateway/cmd/gateway@${EBUSGATEWAY_VERSION}
+
 FROM ${BUILD_FROM}
 
+COPY --from=builder /out/gateway /usr/local/bin/helianthus-gateway
 COPY rootfs/ /
-
-CMD ["/bin/bash", "-c", "echo \"Helianthus HA add-on placeholder\"; sleep infinity"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,25 @@
 # Helianthus Home Assistant Add-on
 
-Minimal bootstrap repository for a Home Assistant add-on. No functional integration is included yet.
+Home Assistant add-on that runs the Helianthus eBUS gateway (GraphQL + MCP).
 
 ## Status
 
-- Skeleton add-on structure only
-- Placeholder container command
-- No HA services, ports, or config
+- Builds and runs `helianthus-ebusgateway`
+- Exposes GraphQL + MCP over HTTP
+- Advertises `_helianthus-graphql._tcp` via mDNS (optional)
+
+## Defaults
+
+- GraphQL: `http://<host>:8080/graphql`
+- Subscriptions: `http://<host>:8080/graphql/subscriptions`
+- MCP: `http://<host>:8080/mcp`
+
+## Configuration
+
+Key options are exposed in `config.json`:
+
+- `transport`: `enh` or `ens`
+- `network`: `tcp` or `unix`
+- `address`: transport address (e.g. `192.168.100.2:9999`)
+- `http_port`: HTTP listen port
+- `mdns`: enable/disable mDNS advertisement

--- a/config.json
+++ b/config.json
@@ -1,12 +1,48 @@
 {
   "name": "Helianthus",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "slug": "helianthus",
-  "description": "Helianthus eBUS add-on (placeholder)",
+  "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
   "startup": "services",
   "boot": "auto",
   "init": false,
-  "options": {},
-  "schema": {}
+  "host_network": true,
+  "ports": {
+    "8080/tcp": 8080
+  },
+  "ports_description": {
+    "8080/tcp": "GraphQL + MCP HTTP server"
+  },
+  "image": "ghcr.io/d3vi1/helianthus-ha-addon",
+  "options": {
+    "transport": "enh",
+    "network": "tcp",
+    "address": "192.168.100.2:9999",
+    "http_port": 8080,
+    "graphql_path": "/graphql",
+    "subscription_path": "/graphql/subscriptions",
+    "mcp_path": "/mcp",
+    "mdns": true,
+    "mdns_instance": "helianthus",
+    "broadcast": false,
+    "read_timeout": "5s",
+    "write_timeout": "5s",
+    "dial_timeout": "5s"
+  },
+  "schema": {
+    "transport": "list(enh|ens)",
+    "network": "list(tcp|unix)",
+    "address": "str",
+    "http_port": "int",
+    "graphql_path": "str",
+    "subscription_path": "str",
+    "mcp_path": "str",
+    "mdns": "bool",
+    "mdns_instance": "str",
+    "broadcast": "bool",
+    "read_timeout": "str",
+    "write_timeout": "str",
+    "dial_timeout": "str"
+  }
 }

--- a/rootfs/run.sh
+++ b/rootfs/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/with-contenv bashio
+
+set -euo pipefail
+
+transport=$(bashio::config 'transport')
+network=$(bashio::config 'network')
+address=$(bashio::config 'address')
+http_port=$(bashio::config 'http_port')
+graphql_path=$(bashio::config 'graphql_path')
+subscription_path=$(bashio::config 'subscription_path')
+mcp_path=$(bashio::config 'mcp_path')
+mdns=$(bashio::config 'mdns')
+mdns_instance=$(bashio::config 'mdns_instance')
+broadcast=$(bashio::config 'broadcast')
+read_timeout=$(bashio::config 'read_timeout')
+write_timeout=$(bashio::config 'write_timeout')
+dial_timeout=$(bashio::config 'dial_timeout')
+
+if [ -z "${http_port}" ]; then
+  http_port=8080
+fi
+
+http_addr="0.0.0.0:${http_port}"
+
+bashio::log.info "Starting Helianthus gateway on ${http_addr}"
+
+exec /usr/local/bin/helianthus-gateway \
+  -transport "${transport}" \
+  -network "${network}" \
+  -address "${address}" \
+  -http-addr "${http_addr}" \
+  -graphql-path "${graphql_path}" \
+  -subscription-path "${subscription_path}" \
+  -mcp-path "${mcp_path}" \
+  -mdns="${mdns}" \
+  -mdns-instance "${mdns_instance}" \
+  -broadcast="${broadcast}" \
+  -read-timeout "${read_timeout}" \
+  -write-timeout "${write_timeout}" \
+  -dial-timeout "${dial_timeout}"


### PR DESCRIPTION
Closes #1.

## Summary
- Build helianthus-ebusgateway in a multi-stage Dockerfile
- Add run script wiring HA options to gateway flags
- Expose config, ports, and mDNS defaults
- Add GHCR build workflow

## Testing
- Not run (container build in CI)