### PR TITLE
Use REPO_READ_TOKEN in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,4 +44,4 @@ jobs:
           build-args: |
             EBUSGATEWAY_VERSION=main
           secrets: |
-            github_token=${{ secrets.PRIVATE_REPO_READ_TOKEN }}
+            github_token=${{ secrets.REPO_READ_TOKEN }}


### PR DESCRIPTION
Closes #3.

## Summary
- Switch build workflow secret to REPO_READ_TOKEN

## Testing
- Not run (CI workflow change)