### PR TITLE
Use multi-arch base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,5 +43,6 @@ jobs:
             ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}
           build-args: |
             EBUSGATEWAY_VERSION=main
+            BUILD_FROM=ghcr.io/home-assistant/base:3.19
           secrets: |
             github_token=${{ secrets.REPO_READ_TOKEN }}

--- a/helianthus/Dockerfile
+++ b/helianthus/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 
-ARG BUILD_FROM=ghcr.io/home-assistant/amd64-base:3.19
+ARG BUILD_FROM=ghcr.io/home-assistant/base:3.19
 
 FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
 ARG TARGETOS=linux


### PR DESCRIPTION
Closes #7.

## Summary
- Default BUILD_FROM to multi-arch base image
- Pass BUILD_FROM explicitly in CI

## Testing
- Not run (CI build)
