### PR TITLE
feat(addon): runtime gateway transport + endpoint config

### DIFF
--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -18,11 +18,16 @@ Home Assistant add-on that runs the Helianthus eBUS gateway (GraphQL + MCP).
 
 Key options are exposed in `config.json`:
 
-- `transport`: `enh` or `ens`
+- `transport`: `enh`, `ens`, or `ebusd-tcp`
 - `network`: `tcp` or `unix`
 - `address`: transport address (e.g. `HOST:PORT`)
-- `host`: gateway host placeholder
-- `port`: gateway port placeholder
-- `path`: gateway path placeholder
+- `host`: hostname used in startup endpoint logs
+- `port`: simple GraphQL/MCP endpoint port alias
+- `path`: simple GraphQL endpoint path alias
 - `http_port`: HTTP listen port
+- `graphql_path`: GraphQL endpoint path
+- `subscription_path`: GraphQL subscriptions endpoint path
+- `mcp_path`: MCP endpoint path
 - `mdns`: enable/disable mDNS advertisement
+
+For ebusd TCP mode, use `transport=ebusd-tcp`, `network=tcp`, and set `address=<ebusd-host>:<ebusd-port>`.

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -34,7 +34,7 @@
     "dial_timeout": "5s"
   },
   "schema": {
-    "transport": "list(enh|ens)",
+    "transport": "list(enh|ens|ebusd-tcp)",
     "network": "list(tcp|unix)",
     "address": "str",
     "host": "str",

--- a/helianthus/rootfs/run.sh
+++ b/helianthus/rootfs/run.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 transport=$(bashio::config 'transport')
 network=$(bashio::config 'network')
 address=$(bashio::config 'address')
+host=$(bashio::config 'host')
+port=$(bashio::config 'port')
+path=$(bashio::config 'path')
 http_port=$(bashio::config 'http_port')
 graphql_path=$(bashio::config 'graphql_path')
 subscription_path=$(bashio::config 'subscription_path')
@@ -20,9 +23,47 @@ if [ -z "${http_port}" ]; then
   http_port=8080
 fi
 
+if [ -n "${port}" ] && { [ "${http_port}" = "8080" ] || [ "${port}" != "8080" ]; }; then
+  http_port="${port}"
+fi
+
+if [ -z "${path}" ]; then
+  path="${graphql_path}"
+fi
+
+if [ -n "${path}" ] && { [ "${graphql_path}" = "/graphql" ] || [ "${path}" != "/graphql" ]; }; then
+  graphql_path="${path}"
+fi
+
+if [ -z "${host}" ]; then
+  host="127.0.0.1"
+fi
+
+if [ "${graphql_path#/}" = "${graphql_path}" ]; then
+  graphql_path="/${graphql_path}"
+fi
+
+if [ "${subscription_path#/}" = "${subscription_path}" ]; then
+  subscription_path="/${subscription_path}"
+fi
+
+if [ "${mcp_path#/}" = "${mcp_path}" ]; then
+  mcp_path="/${mcp_path}"
+fi
+
+if [ "${subscription_path}" = "/graphql/subscriptions" ] && [ "${graphql_path}" != "/graphql" ]; then
+  subscription_path="${graphql_path%/}/subscriptions"
+fi
+
 http_addr="0.0.0.0:${http_port}"
 
-bashio::log.info "Starting Helianthus gateway on ${http_addr}"
+bashio::log.info "Starting Helianthus gateway"
+bashio::log.info "Transport: ${transport} (${network} ${address})"
+bashio::log.info "HTTP listen: ${http_addr}"
+bashio::log.info "GraphQL endpoint: http://${host}:${http_port}${graphql_path}"
+bashio::log.info "Subscriptions endpoint: http://${host}:${http_port}${subscription_path}"
+bashio::log.info "MCP endpoint: http://${host}:${http_port}${mcp_path}"
+bashio::log.info "mDNS: enabled=${mdns} instance=${mdns_instance}"
 
 exec /usr/local/bin/helianthus-gateway \
   -transport "${transport}" \


### PR DESCRIPTION
## Summary
- start gateway with explicit runtime startup logs (transport, listen address, and exposed endpoints)
- wire simple endpoint aliases (`host`/`port`/`path`) into runtime defaults for gateway startup
- add `ebusd-tcp` as an allowed `transport` schema value
- update add-on docs for runtime transport/endpoint options

Closes #12.

## Acceptance Checklist
- [x] Add-on starts gateway with configurable transport and endpoint
- [x] Logs expose gateway status
- [x] Add-on options schema documented
- [ ] CI green

@codex review
