### PR TITLE
Add initiator/target terminology guard in PR CI

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -43,3 +43,12 @@ jobs:
           if [ "${found}" -eq 0 ]; then
             echo "No shell files found."
           fi
+
+      - name: Enforce terminology
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git grep -nIwiE 'm[a]ster|s[l]ave'; then
+            echo "Found legacy terminology in tracked files."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- confirm tracked files contain no whole-word legacy role terms
- minimally extend existing `pr-ci` workflow with a terminology grep gate
- preserve add-on behavior and release workflow semantics

## Local checks
- JSON syntax validation (`python3 -m json.tool` over tracked `*.json`)
- shell syntax validation (`bash -n` over tracked `*.sh`)
- `git grep -nIwE '(master|slave)'`

Closes #22

@codex review
