### PR TITLE
M3 smoke: add add-on ebusd-tcp runbook and checklist

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -52,3 +52,9 @@ jobs:
             echo "Found legacy terminology in tracked files."
             exit 1
           fi
+
+      - name: Validate smoke runbook structure
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/validate_smoke_docs.py

--- a/README.md
+++ b/README.md
@@ -132,6 +132,13 @@ GitHub Actions workflow: `.github/workflows/build.yml`
 - Default exposed port is `8080/tcp`.
 - This repository is packaging/runtime glue only; gateway feature behavior lives in `helianthus-ebusgateway`.
 
+## Smoke runbook
+
+For local `ebusd-tcp` operator validation (install/start/config + deterministic endpoint/log checklist), use:
+
+- `SMOKE_RUNBOOK.md`
+- `scripts/smoke_addon_checklist.py`
+
 ## Troubleshooting
 
 - Add-on starts but no data: verify `transport`/`network`/`address` match your real backend endpoint.

--- a/SMOKE_RUNBOOK.md
+++ b/SMOKE_RUNBOOK.md
@@ -1,0 +1,127 @@
+# Helianthus HA Add-on Smoke Runbook
+
+This runbook validates the Home Assistant add-on path with a local `ebusd-tcp` topology and produces deterministic pass/fail output.
+
+## Local ebusd-tcp topology
+
+- Home Assistant Supervisor runs the `helianthus` add-on.
+- Add-on transport points to local/lan ebusd TCP endpoint.
+- Example topology values used below:
+  - ebusd endpoint: `192.168.100.2:9999`
+  - add-on HTTP API: `127.0.0.1:8080`
+  - GraphQL path: `/graphql`
+  - Subscriptions path: `/graphql/subscriptions`
+  - MCP path: `/mcp`
+
+## Install and start add-on
+
+1) Add repository:
+
+```bash
+ha addons repo add https://github.com/d3vi1/helianthus-ha-addon
+```
+
+2) Install and start the `helianthus` add-on from Home Assistant Add-on Store.
+
+3) Open add-on **Configuration** and paste the configuration payload below.
+
+## Add-on configuration (copy/paste)
+
+<!-- smoke-config-json:start -->
+```json
+{
+  "transport": "ebusd-tcp",
+  "network": "tcp",
+  "address": "192.168.100.2:9999",
+  "host": "127.0.0.1",
+  "http_port": 8080,
+  "graphql_path": "/graphql",
+  "subscription_path": "/graphql/subscriptions",
+  "mcp_path": "/mcp",
+  "mdns": true,
+  "mdns_instance": "helianthus",
+  "broadcast": false,
+  "read_timeout": "5s",
+  "write_timeout": "5s",
+  "dial_timeout": "5s"
+}
+```
+<!-- smoke-config-json:end -->
+
+After saving config, restart the add-on.
+
+## Deterministic smoke checklist
+
+1) Export add-on logs:
+
+```bash
+ha addons logs helianthus > /tmp/helianthus-addon.log
+```
+
+2) Run checklist:
+
+```bash
+python3 scripts/smoke_addon_checklist.py \
+  --log-file /tmp/helianthus-addon.log \
+  --transport ebusd-tcp \
+  --network tcp \
+  --address 192.168.100.2:9999 \
+  --host 127.0.0.1 \
+  --http-port 8080 \
+  --graphql-path /graphql \
+  --subscription-path /graphql/subscriptions \
+  --mcp-path /mcp
+```
+
+3) Optional JSON output:
+
+```bash
+python3 scripts/smoke_addon_checklist.py \
+  --log-file /tmp/helianthus-addon.log \
+  --transport ebusd-tcp \
+  --network tcp \
+  --address 192.168.100.2:9999 \
+  --host 127.0.0.1 \
+  --http-port 8080 \
+  --graphql-path /graphql \
+  --subscription-path /graphql/subscriptions \
+  --mcp-path /mcp \
+  --json
+```
+
+Checklist IDs (stable order):
+
+<!-- smoke-checklist:start -->
+```text
+- [ ] CHECK_CONNECTION_GRAPHQL
+- [ ] CHECK_CONNECTION_MCP
+- [ ] CHECK_LOG_STARTUP
+- [ ] CHECK_LOG_TRANSPORT
+- [ ] CHECK_LOG_GRAPHQL_ENDPOINT
+- [ ] CHECK_LOG_SUBSCRIPTION_ENDPOINT
+- [ ] CHECK_LOG_MCP_ENDPOINT
+```
+<!-- smoke-checklist:end -->
+
+Expected final line:
+
+```text
+OVERALL PASS
+```
+
+Exit code:
+
+- `0` when all checks pass
+- `1` when any check fails
+
+## Failure triage
+
+| Check ID | Primary failure meaning | First action |
+| --- | --- | --- |
+| CHECK_CONNECTION_GRAPHQL | GraphQL endpoint not reachable or invalid response | Verify add-on is running and `graphql_path/http_port` settings, then restart |
+| CHECK_CONNECTION_MCP | MCP endpoint not reachable or tools/list failed | Verify `mcp_path` and supervisor/network reachability |
+| CHECK_LOG_STARTUP | Startup marker missing | Confirm add-on process starts and does not crash early |
+| CHECK_LOG_TRANSPORT | Transport marker mismatch | Verify `transport/network/address` options for ebusd-tcp |
+| CHECK_LOG_GRAPHQL_ENDPOINT | GraphQL endpoint marker mismatch | Verify `host/http_port/graphql_path` in add-on config |
+| CHECK_LOG_SUBSCRIPTION_ENDPOINT | Subscriptions marker mismatch | Verify `subscription_path` and graphql path normalization |
+| CHECK_LOG_MCP_ENDPOINT | MCP marker mismatch | Verify `mcp_path` normalization and startup options |

--- a/scripts/smoke_addon_checklist.py
+++ b/scripts/smoke_addon_checklist.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Deterministic smoke checklist for local HA add-on operator runs."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlunsplit
+from urllib.request import Request, urlopen
+
+CHECK_CONNECTION_GRAPHQL = "CHECK_CONNECTION_GRAPHQL"
+CHECK_CONNECTION_MCP = "CHECK_CONNECTION_MCP"
+CHECK_LOG_STARTUP = "CHECK_LOG_STARTUP"
+CHECK_LOG_TRANSPORT = "CHECK_LOG_TRANSPORT"
+CHECK_LOG_GRAPHQL_ENDPOINT = "CHECK_LOG_GRAPHQL_ENDPOINT"
+CHECK_LOG_SUBSCRIPTION_ENDPOINT = "CHECK_LOG_SUBSCRIPTION_ENDPOINT"
+CHECK_LOG_MCP_ENDPOINT = "CHECK_LOG_MCP_ENDPOINT"
+
+TRIAGE = {
+    CHECK_CONNECTION_GRAPHQL: "verify addon started and graphql_path/http_port are reachable",
+    CHECK_CONNECTION_MCP: "verify mcp_path/http_port and supervisor host-network reachability",
+    CHECK_LOG_STARTUP: "verify add-on process did not exit before gateway startup",
+    CHECK_LOG_TRANSPORT: "verify transport/network/address options match local ebusd-tcp target",
+    CHECK_LOG_GRAPHQL_ENDPOINT: "verify host/http_port/graphql_path options and restart add-on",
+    CHECK_LOG_SUBSCRIPTION_ENDPOINT: "verify subscription_path and graphql_path normalization",
+    CHECK_LOG_MCP_ENDPOINT: "verify mcp_path normalization and gateway startup options",
+}
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    check: str
+    ok: bool
+    details: str
+    triage: str
+
+
+@dataclass(frozen=True)
+class SmokeChecklist:
+    version: str
+    checks: list[CheckResult]
+
+    @property
+    def ok(self) -> bool:
+        return all(item.ok for item in self.checks)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "ok": self.ok,
+            "checks": [asdict(item) for item in self.checks],
+        }
+
+    def as_lines(self) -> list[str]:
+        lines = [f"HELIANTHUS_ADDON_SMOKE {self.version}"]
+        for item in self.checks:
+            state = "PASS" if item.ok else "FAIL"
+            lines.append(f"[{state}] {item.check} :: {item.details} | triage={item.triage}")
+        lines.append(f"OVERALL {'PASS' if self.ok else 'FAIL'}")
+        return lines
+
+
+def _post_json(url: str, payload: dict[str, Any], timeout: float) -> dict[str, Any]:
+    raw = json.dumps(payload).encode("utf-8")
+    request = Request(
+        url,
+        data=raw,
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            response_bytes = response.read()
+    except HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"http {exc.code}: {body}") from exc
+    except URLError as exc:
+        raise RuntimeError(f"connection error: {exc.reason}") from exc
+    except TimeoutError as exc:
+        raise RuntimeError("timeout") from exc
+
+    try:
+        decoded = json.loads(response_bytes.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"invalid json response: {exc}") from exc
+    if not isinstance(decoded, dict):
+        raise RuntimeError("response is not a json object")
+    return decoded
+
+
+def _check_graphql(graphql_url: str, timeout: float) -> CheckResult:
+    try:
+        response = _post_json(graphql_url, {"query": "{ __typename }", "variables": {}}, timeout)
+    except RuntimeError as exc:
+        return CheckResult(CHECK_CONNECTION_GRAPHQL, False, str(exc), TRIAGE[CHECK_CONNECTION_GRAPHQL])
+
+    errors = response.get("errors")
+    if isinstance(errors, list) and errors:
+        return CheckResult(
+            CHECK_CONNECTION_GRAPHQL,
+            False,
+            f"graphql errors={_join_messages(errors)}",
+            TRIAGE[CHECK_CONNECTION_GRAPHQL],
+        )
+    data = response.get("data")
+    typename = None if not isinstance(data, dict) else data.get("__typename")
+    if not isinstance(typename, str) or typename.strip() == "":
+        return CheckResult(
+            CHECK_CONNECTION_GRAPHQL,
+            False,
+            "missing __typename field",
+            TRIAGE[CHECK_CONNECTION_GRAPHQL],
+        )
+    return CheckResult(
+        CHECK_CONNECTION_GRAPHQL,
+        True,
+        f"typename={typename}",
+        "none",
+    )
+
+
+def _check_mcp(mcp_url: str, timeout: float) -> CheckResult:
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}
+    try:
+        response = _post_json(mcp_url, payload, timeout)
+    except RuntimeError as exc:
+        return CheckResult(CHECK_CONNECTION_MCP, False, str(exc), TRIAGE[CHECK_CONNECTION_MCP])
+
+    error = response.get("error")
+    if isinstance(error, dict):
+        message = str(error.get("message", "")).strip() or "rpc error"
+        return CheckResult(
+            CHECK_CONNECTION_MCP,
+            False,
+            f"rpc_error={message}",
+            TRIAGE[CHECK_CONNECTION_MCP],
+        )
+    result = response.get("result")
+    tools = None if not isinstance(result, dict) else result.get("tools")
+    if not isinstance(tools, list) or len(tools) == 0:
+        return CheckResult(
+            CHECK_CONNECTION_MCP,
+            False,
+            "missing or empty tools list",
+            TRIAGE[CHECK_CONNECTION_MCP],
+        )
+    return CheckResult(
+        CHECK_CONNECTION_MCP,
+        True,
+        f"tools={len(tools)}",
+        "none",
+    )
+
+
+def _check_marker(check: str, log_text: str, marker: str) -> CheckResult:
+    if marker in log_text:
+        return CheckResult(check, True, f'marker="{marker}"', "none")
+    return CheckResult(
+        check,
+        False,
+        f'missing marker="{marker}"',
+        TRIAGE[check],
+    )
+
+
+def run_checklist(
+    *,
+    log_text: str,
+    graphql_url: str,
+    mcp_url: str,
+    expected_transport: str,
+    expected_network: str,
+    expected_address: str,
+    expected_graphql_marker: str,
+    expected_subscription_marker: str,
+    expected_mcp_marker: str,
+    timeout: float,
+) -> SmokeChecklist:
+    checks = [
+        _check_graphql(graphql_url, timeout),
+        _check_mcp(mcp_url, timeout),
+        _check_marker(CHECK_LOG_STARTUP, log_text, "Starting Helianthus gateway"),
+        _check_marker(
+            CHECK_LOG_TRANSPORT,
+            log_text,
+            f"Transport: {expected_transport} ({expected_network} {expected_address})",
+        ),
+        _check_marker(CHECK_LOG_GRAPHQL_ENDPOINT, log_text, expected_graphql_marker),
+        _check_marker(CHECK_LOG_SUBSCRIPTION_ENDPOINT, log_text, expected_subscription_marker),
+        _check_marker(CHECK_LOG_MCP_ENDPOINT, log_text, expected_mcp_marker),
+    ]
+    return SmokeChecklist(version="v1", checks=checks)
+
+
+def _join_messages(items: list[Any]) -> str:
+    messages: list[str] = []
+    for item in items:
+        if isinstance(item, dict):
+            message = str(item.get("message", "")).strip()
+            if message:
+                messages.append(message)
+        elif item:
+            messages.append(str(item))
+    return "; ".join(messages) if messages else "unknown"
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.strip() or "/"
+    if not normalized.startswith("/"):
+        normalized = f"/{normalized}"
+    return normalized
+
+
+def _build_url(host: str, port: int, path: str) -> str:
+    return urlunsplit(("http", f"{host}:{port}", _normalize_path(path), "", ""))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run deterministic smoke checklist for Helianthus HA add-on.",
+    )
+    parser.add_argument("--log-file", required=True, help="Path to exported add-on logs file.")
+    parser.add_argument(
+        "--transport",
+        default="ebusd-tcp",
+        help="Expected transport marker value.",
+    )
+    parser.add_argument(
+        "--network",
+        default="tcp",
+        help="Expected network marker value.",
+    )
+    parser.add_argument(
+        "--address",
+        required=True,
+        help="Expected transport address marker value (for example 192.168.100.2:9999).",
+    )
+    parser.add_argument("--host", default="127.0.0.1", help="Expected endpoint host in startup log markers.")
+    parser.add_argument("--http-port", type=int, default=8080, help="Expected endpoint port in startup markers.")
+    parser.add_argument("--graphql-path", default="/graphql", help="Expected graphql path in markers.")
+    parser.add_argument(
+        "--subscription-path",
+        default="/graphql/subscriptions",
+        help="Expected subscriptions path in markers.",
+    )
+    parser.add_argument("--mcp-path", default="/mcp", help="Expected mcp path in markers.")
+    parser.add_argument("--timeout", type=float, default=10.0, help="Endpoint request timeout seconds.")
+    parser.add_argument("--json", action="store_true", help="Output JSON instead of checklist text.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    with open(args.log_file, "r", encoding="utf-8") as handle:
+        log_text = handle.read()
+
+    graphql_url = _build_url(args.host, args.http_port, args.graphql_path)
+    mcp_url = _build_url(args.host, args.http_port, args.mcp_path)
+    subscription_url = _build_url(args.host, args.http_port, args.subscription_path)
+
+    result = run_checklist(
+        log_text=log_text,
+        graphql_url=graphql_url,
+        mcp_url=mcp_url,
+        expected_transport=args.transport,
+        expected_network=args.network,
+        expected_address=args.address,
+        expected_graphql_marker=f"GraphQL endpoint: {graphql_url}",
+        expected_subscription_marker=f"Subscriptions endpoint: {subscription_url}",
+        expected_mcp_marker=f"MCP endpoint: {mcp_url}",
+        timeout=args.timeout,
+    )
+
+    if args.json:
+        print(json.dumps(result.as_dict(), indent=2, sort_keys=True))
+    else:
+        for line in result.as_lines():
+            print(line)
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_smoke_docs.py
+++ b/scripts/validate_smoke_docs.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Validate smoke runbook structure and config/checklist syntax."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import sys
+
+RUNBOOK_PATH = Path("SMOKE_RUNBOOK.md")
+
+REQUIRED_HEADINGS = [
+    "## Local ebusd-tcp topology",
+    "## Install and start add-on",
+    "## Add-on configuration (copy/paste)",
+    "## Deterministic smoke checklist",
+    "## Failure triage",
+]
+
+REQUIRED_CONFIG_KEYS = [
+    "transport",
+    "network",
+    "address",
+    "host",
+    "http_port",
+    "graphql_path",
+    "subscription_path",
+    "mcp_path",
+    "mdns",
+]
+
+REQUIRED_CHECKS = [
+    "CHECK_CONNECTION_GRAPHQL",
+    "CHECK_CONNECTION_MCP",
+    "CHECK_LOG_STARTUP",
+    "CHECK_LOG_TRANSPORT",
+    "CHECK_LOG_GRAPHQL_ENDPOINT",
+    "CHECK_LOG_SUBSCRIPTION_ENDPOINT",
+    "CHECK_LOG_MCP_ENDPOINT",
+]
+
+
+def _extract_marker_block(text: str, marker: str) -> str:
+    pattern = re.compile(
+        rf"<!--\s*{re.escape(marker)}:start\s*-->\s*```[a-zA-Z0-9_-]*\s*(.*?)```[\r\n]+<!--\s*{re.escape(marker)}:end\s*-->",
+        re.DOTALL,
+    )
+    match = pattern.search(text)
+    if not match:
+        raise ValueError(f"missing marker block for {marker}")
+    return match.group(1).strip()
+
+
+def main() -> int:
+    if not RUNBOOK_PATH.exists():
+        print(f"missing {RUNBOOK_PATH}")
+        return 1
+
+    text = RUNBOOK_PATH.read_text(encoding="utf-8")
+
+    for heading in REQUIRED_HEADINGS:
+        if heading not in text:
+            print(f"missing heading: {heading}")
+            return 1
+
+    try:
+        config_block = _extract_marker_block(text, "smoke-config-json")
+        config_payload = json.loads(config_block)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"invalid smoke config block: {exc}")
+        return 1
+
+    if not isinstance(config_payload, dict):
+        print("smoke config block must be a JSON object")
+        return 1
+
+    for key in REQUIRED_CONFIG_KEYS:
+        if key not in config_payload:
+            print(f"smoke config missing key: {key}")
+            return 1
+
+    if config_payload.get("transport") != "ebusd-tcp":
+        print("smoke config transport must be ebusd-tcp")
+        return 1
+    if config_payload.get("network") != "tcp":
+        print("smoke config network must be tcp")
+        return 1
+
+    checklist_section = _extract_marker_block(text, "smoke-checklist")
+    lines = [line.strip() for line in checklist_section.splitlines() if line.strip()]
+    check_ids = []
+    for line in lines:
+        prefix = "- [ ] "
+        if not line.startswith(prefix):
+            print(f"invalid checklist line format: {line}")
+            return 1
+        check_id = line[len(prefix) :].split(" ", 1)[0].strip()
+        check_ids.append(check_id)
+
+    if check_ids != REQUIRED_CHECKS:
+        print(f"checklist ids mismatch: {check_ids}")
+        return 1
+
+    triage_rows = {
+        match.group(1)
+        for match in re.finditer(r"^\|\s*(CHECK_[A-Z_]+)\s*\|", text, flags=re.MULTILINE)
+    }
+    for check in REQUIRED_CHECKS:
+        if check not in triage_rows:
+            print(f"missing triage row for {check}")
+            return 1
+
+    print("Smoke runbook validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What
Add deterministic add-on smoke runbook and checklist tooling for local ebusd-tcp operator topology.

## Why
Issue #24 requires a repeatable verification path for install/start/config plus endpoint and log marker health checks.

## Changes
- add `SMOKE_RUNBOOK.md` with local ebusd-tcp topology, config payload, checklist execution, and triage table
- add `scripts/smoke_addon_checklist.py` for deterministic PASS/FAIL checks against GraphQL, MCP, and startup log markers
- add `scripts/validate_smoke_docs.py` to enforce smoke runbook structure and syntax
- wire smoke docs validation into PR CI workflow (`.github/workflows/pr-ci.yml`)
- link smoke runbook from `README.md`

## Local validation
- `python3 scripts/validate_smoke_docs.py`
- `python3 -m py_compile scripts/smoke_addon_checklist.py scripts/validate_smoke_docs.py`
- PR-CI-equivalent checks (json syntax, shell syntax, terminology, smoke runbook validation)

Closes #24