### PR TITLE
fix: align smoke subscription marker derivation

### DIFF
--- a/scripts/smoke_addon_checklist.py
+++ b/scripts/smoke_addon_checklist.py
@@ -19,6 +19,9 @@ CHECK_LOG_GRAPHQL_ENDPOINT = "CHECK_LOG_GRAPHQL_ENDPOINT"
 CHECK_LOG_SUBSCRIPTION_ENDPOINT = "CHECK_LOG_SUBSCRIPTION_ENDPOINT"
 CHECK_LOG_MCP_ENDPOINT = "CHECK_LOG_MCP_ENDPOINT"
 
+DEFAULT_GRAPHQL_PATH = "/graphql"
+DEFAULT_SUBSCRIPTION_PATH = "/graphql/subscriptions"
+
 TRIAGE = {
     CHECK_CONNECTION_GRAPHQL: "verify addon started and graphql_path/http_port are reachable",
     CHECK_CONNECTION_MCP: "verify mcp_path/http_port and supervisor host-network reachability",
@@ -218,6 +221,17 @@ def _build_url(host: str, port: int, path: str) -> str:
     return urlunsplit(("http", f"{host}:{port}", _normalize_path(path), "", ""))
 
 
+def _derive_subscription_path(graphql_path: str, subscription_path: str) -> str:
+    normalized_graphql_path = _normalize_path(graphql_path)
+    normalized_subscription_path = _normalize_path(subscription_path)
+    if (
+        normalized_subscription_path == DEFAULT_SUBSCRIPTION_PATH
+        and normalized_graphql_path != DEFAULT_GRAPHQL_PATH
+    ):
+        return f"{normalized_graphql_path.rstrip('/')}/subscriptions"
+    return normalized_subscription_path
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Run deterministic smoke checklist for Helianthus HA add-on.",
@@ -257,9 +271,11 @@ def main() -> int:
     with open(args.log_file, "r", encoding="utf-8") as handle:
         log_text = handle.read()
 
-    graphql_url = _build_url(args.host, args.http_port, args.graphql_path)
+    graphql_path = _normalize_path(args.graphql_path)
+    subscription_path = _derive_subscription_path(graphql_path, args.subscription_path)
+    graphql_url = _build_url(args.host, args.http_port, graphql_path)
     mcp_url = _build_url(args.host, args.http_port, args.mcp_path)
-    subscription_url = _build_url(args.host, args.http_port, args.subscription_path)
+    subscription_url = _build_url(args.host, args.http_port, subscription_path)
 
     result = run_checklist(
         log_text=log_text,

--- a/scripts/validate_smoke_docs.py
+++ b/scripts/validate_smoke_docs.py
@@ -3,12 +3,14 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 from pathlib import Path
 import re
 import sys
 
 RUNBOOK_PATH = Path("SMOKE_RUNBOOK.md")
+SMOKE_CHECKLIST_PATH = Path(__file__).with_name("smoke_addon_checklist.py")
 
 REQUIRED_HEADINGS = [
     "## Local ebusd-tcp topology",
@@ -39,6 +41,17 @@ REQUIRED_CHECKS = [
     "CHECK_LOG_SUBSCRIPTION_ENDPOINT",
     "CHECK_LOG_MCP_ENDPOINT",
 ]
+
+
+def _load_smoke_checklist_module():
+    module_name = "smoke_addon_checklist_runtime"
+    spec = importlib.util.spec_from_file_location(module_name, SMOKE_CHECKLIST_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {SMOKE_CHECKLIST_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
 
 
 def _extract_marker_block(text: str, marker: str) -> str:
@@ -110,6 +123,30 @@ def main() -> int:
         if check not in triage_rows:
             print(f"missing triage row for {check}")
             return 1
+
+    smoke_addon_checklist = _load_smoke_checklist_module()
+
+    derived_subscription = smoke_addon_checklist._derive_subscription_path(
+        "/api/graphql",
+        "/graphql/subscriptions",
+    )
+    if derived_subscription != "/api/graphql/subscriptions":
+        print(
+            "subscription marker derivation mismatch for customized graphql_path: "
+            f"{derived_subscription}",
+        )
+        return 1
+
+    explicit_subscription = smoke_addon_checklist._derive_subscription_path(
+        "/api/graphql",
+        "/custom/subscriptions",
+    )
+    if explicit_subscription != "/custom/subscriptions":
+        print(
+            "subscription marker derivation mismatch for explicit subscription_path: "
+            f"{explicit_subscription}",
+        )
+        return 1
 
     print("Smoke runbook validation passed.")
     return 0


### PR DESCRIPTION
## Summary
- align `scripts/smoke_addon_checklist.py` subscription endpoint expectation with `helianthus/rootfs/run.sh` derivation logic
- when `graphql_path` is customized and `subscription_path` remains default, derive expected subscription marker as `<graphql_path>/subscriptions`
- add validation coverage in `scripts/validate_smoke_docs.py` for both derived-default and explicit subscription path scenarios

## Validation
- python3 scripts/validate_smoke_docs.py
- python3 -m py_compile scripts/smoke_addon_checklist.py scripts/validate_smoke_docs.py
- bash -n helianthus/rootfs/run.sh

Closes #26
