### PR TITLE
README refresh for practical onboarding and operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,69 @@
 # helianthus-ha-addon
 
-Home Assistant add-on repository for Helianthus.
-This add-on runs `helianthus-gateway` in a Supervisor container and exposes GraphQL/MCP endpoints to Home Assistant operators.
+`helianthus-ha-addon` is the Home Assistant add-on packaging layer for Helianthus gateway runtime. It runs `helianthus-gateway` in Supervisor and exposes GraphQL/MCP endpoints to Home Assistant operators.
 
-## What this add-on does
+## Purpose and Scope
 
-- Runs `helianthus-gateway` inside a Home Assistant add-on container
-- Connects runtime to an external eBUS transport (`enh`, `ens`, or `ebusd-tcp`)
-- Serves HTTP endpoints for GraphQL, GraphQL subscriptions, and MCP
-- Optionally advertises GraphQL over mDNS (`_helianthus-graphql._tcp`)
+### What belongs in this repository
 
-Repository layout:
+- Add-on metadata and options schema (`repository.json`, `helianthus/config.json`).
+- Add-on runtime startup wiring (`helianthus/rootfs/run.sh`).
+- Add-on image build definition (`helianthus/Dockerfile`).
+- Add-on smoke docs/check tooling (`SMOKE_RUNBOOK.md`, `scripts/smoke_addon_checklist.py`).
 
-- `repository.json`: add-on repository metadata
-- `helianthus/config.json`: add-on manifest, defaults, and options schema
-- `helianthus/rootfs/run.sh`: config-to-runtime mapping and startup command
-- `helianthus/Dockerfile`: image build (installs `github.com/d3vi1/helianthus-ebusgateway/cmd/gateway`)
+### What does not belong in this repository
 
-## Install and start (operators)
+- eBUS transport/protocol implementation (`helianthus-ebusgo`).
+- Registry/schema/device semantics (`helianthus-ebusreg`).
+- Gateway application logic (`helianthus-ebusgateway`).
+- Home Assistant integration entity model (`helianthus-ha-integration`).
+
+## Status and Maturity
+
+- Active add-on packaging repo with CI syntax/docs checks.
+- Suitable for practical onboarding and operator runbook usage.
+- Runtime behavior is driven by add-on options and upstream gateway capabilities.
+
+## Helianthus Dependency Chain
+
+```text
+helianthus-ebusgo -> helianthus-ebusreg -> helianthus-ebusgateway -> helianthus-ha-addon -> Home Assistant Supervisor
+  (transport)        (registry/schema)     (runtime/API)             (addon packaging)
+```
+
+## Quickstart (copy/paste)
+
+### 0) Prerequisites
+
+- Home Assistant OS or Home Assistant Supervised (Supervisor add-ons enabled).
+- Reachable eBUS backend endpoint (`enh` / `ens` / `ebusd-tcp`).
+- `python3` and `bash` for local docs/check scripts.
+
+### 1) Clone and run local validation checks
+
+```bash
+git clone https://github.com/d3vi1/helianthus-ha-addon.git
+cd helianthus-ha-addon
+python3 -m json.tool repository.json >/dev/null
+python3 -m json.tool helianthus/config.json >/dev/null
+bash -n helianthus/rootfs/run.sh
+if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi
+python3 scripts/validate_smoke_docs.py
+python3 scripts/smoke_addon_checklist.py --help
+```
+
+### 2) Add repository to Home Assistant and install
 
 ```bash
 ha addons repo add https://github.com/d3vi1/helianthus-ha-addon
 ```
 
-Then in Home Assistant:
+Then install **Helianthus** from the Add-on Store and open add-on configuration.
 
-1. Open **Settings → Add-ons → Add-on Store**
-2. Install **Helianthus**
-3. Set configuration values (matrix below)
-4. Start the add-on
-5. Verify logs and endpoint health (flow below)
-
-Common TCP baseline:
+### 3) Baseline add-on configuration example (local ebusd-tcp)
 
 ```yaml
-transport: enh
+transport: ebusd-tcp
 network: tcp
 address: 192.168.100.2:9999
 proxy_profile: disabled
@@ -46,7 +75,7 @@ mcp_path: /mcp
 mdns: true
 ```
 
-Transition mode via `helianthus-ebus-adapter-proxy` (ENH example):
+### 4) Transition configuration example (adapter-proxy ENH profile)
 
 ```yaml
 transport: enh
@@ -61,135 +90,58 @@ mcp_path: /mcp
 mdns: true
 ```
 
-## Operator config matrix (source: `helianthus/config.json`)
-
-| Option | Schema type | Default | Operator action | Runtime notes |
-| --- | --- | --- | --- | --- |
-| `transport` | `list(enh\|ens\|ebusd-tcp)` | `enh` | Set to your backend protocol | Passed to `-transport` |
-| `network` | `list(tcp\|unix)` | `tcp` | Match your endpoint type | Passed to `-network` |
-| `address` | `str` | `HOST:PORT` | **Required:** replace placeholder with real endpoint/socket | Passed to `-address`; placeholder is not operational |
-| `proxy_profile` | `list(disabled\|enh\|ens)` | `disabled` | Set `enh`/`ens` for transition mode via adapter-proxy | When enabled, runtime forces TCP proxy endpoint and logs profile marker |
-| `proxy_endpoint` | `str` | `""` | Set proxy host:port or endpoint URI | Required when `proxy_profile` is `enh` or `ens`; accepts `host:port` or full URI |
-| `host` | `str` | `127.0.0.1` | Optional | Used for startup endpoint log URLs only; does not change bind address |
-| `port` | `int` | `8080` | Optional compatibility alias | Can override `http_port` (legacy key support) |
-| `path` | `str` | `/graphql` | Optional compatibility alias | Can override `graphql_path` (legacy key support) |
-| `http_port` | `int` | `8080` | Set API listen port | Gateway listens on `0.0.0.0:<http_port>` |
-| `graphql_path` | `str` | `/graphql` | Set GraphQL route | Auto-normalized to include leading `/` |
-| `subscription_path` | `str` | `/graphql/subscriptions` | Usually keep default unless custom route needed | Auto-normalized; auto-derived to `<graphql_path>/subscriptions` when still default and `graphql_path` changes |
-| `mcp_path` | `str` | `/mcp` | Set MCP route | Auto-normalized to include leading `/` |
-| `mdns` | `bool` | `true` | Disable if mDNS is not needed | Passed to `-mdns` |
-| `mdns_instance` | `str` | `helianthus` | Set service instance label | Passed to `-mdns-instance` |
-| `broadcast` | `bool` | `false` | Enable only when backend requires broadcast listener | Passed to `-broadcast` |
-| `read_timeout` | `str` | `5s` | Optional tuning | Passed to `-read-timeout` |
-| `write_timeout` | `str` | `5s` | Optional tuning | Passed to `-write-timeout` |
-| `dial_timeout` | `str` | `5s` | Optional tuning | Passed to `-dial-timeout` |
-
-Compatibility precedence from `run.sh`:
-
-- `port` may override `http_port` for legacy configs
-- `path` may override `graphql_path` for legacy configs
-- if `graphql_path` changes and `subscription_path` stays default, runtime derives `<graphql_path>/subscriptions`
-- if `proxy_profile` is `enh` or `ens`, runtime uses `proxy_endpoint` and emits proxy profile/endpoint startup markers
-
-## Compatibility and runtime assumptions
-
-- Home Assistant OS or Home Assistant Supervised with Supervisor add-on support
-- Add-on runs with `host_network: true` and `startup: services` / `boot: auto`
-- Supported add-on architectures: `aarch64`, `amd64`, `armhf`, `armv7`, `i386`
-- Container must reach the configured transport endpoint (`tcp` host:port or `unix` socket path in-container)
-- Runtime listens on `0.0.0.0:<http_port>`; startup logs print URLs using `host`
-- `ports` metadata exposes `8080/tcp`; with host networking, effective reachability is host-network dependent
-
-## Upgrade / rollback checklist
-
-Before upgrade:
-
-1. Copy current add-on configuration from the Home Assistant UI
-2. Create a Home Assistant backup that includes the Helianthus add-on
-3. Capture baseline logs (`ha addons logs helianthus`) for later diff if needed
-
-Upgrade:
-
-1. Update add-on from the Add-on Store
-2. Start add-on and wait for startup markers in logs
-3. Run the post-install health-check flow below
-
-Rollback (if health-check fails):
-
-1. Stop the add-on
-2. Restore the pre-upgrade Home Assistant backup (preferred)
-3. If backup restore is unavailable, reinstall the previous add-on version (if offered) and reapply saved config
-4. Start add-on and rerun health-check flow
-
-## Post-install smoke health-check flow
-
-Use your configured host/port/path values in commands below.
-
-1. Confirm startup markers:
-   - `Starting Helianthus gateway`
-   - `Transport: ...`
-   - `Proxy profile: ...`
-   - `Proxy endpoint: ...`
-   - `GraphQL endpoint: ...`
-   - `Subscriptions endpoint: ...`
-   - `MCP endpoint: ...`
-2. Check GraphQL:
+### 5) Post-start operator smoke checks
 
 ```bash
 curl -fsS -X POST "http://127.0.0.1:8080/graphql" \
   -H "content-type: application/json" \
   -d '{"query":"{ __typename }","variables":{}}'
-```
 
-3. Check MCP:
-
-```bash
 curl -fsS -X POST "http://127.0.0.1:8080/mcp" \
   -H "content-type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
 ```
 
-4. Optional deterministic smoke checker:
+Deterministic smoke checklist from add-on logs:
 
 ```bash
 ha addons logs helianthus > /tmp/helianthus-addon.log
 python3 scripts/smoke_addon_checklist.py --log-file /tmp/helianthus-addon.log --address 192.168.100.2:9999
 ```
 
-Expected result: `OVERALL PASS`
+For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 
-## Build/deploy flow (maintainers)
+## Validation Commands
 
-### Local image build
+| Area | Command |
+|---|---|
+| JSON syntax | `python3 -m json.tool repository.json >/dev/null` |
+| add-on config syntax | `python3 -m json.tool helianthus/config.json >/dev/null` |
+| shell syntax | `bash -n helianthus/rootfs/run.sh` |
+| terminology gate (CI parity) | `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi` |
+| smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
+| smoke checker CLI | `python3 scripts/smoke_addon_checklist.py --help` |
 
-From repository root:
+## Link Map
 
-```bash
-docker build -f helianthus/Dockerfile helianthus
-```
+### Local docs
 
-For private module access, pass BuildKit secret `github_token` (same secret ID used in `helianthus/Dockerfile`).
-
-### CI and published artifacts
-
-Workflow: `.github/workflows/build.yml`
-
-- Triggers on `main` pushes, `v*` tags, and `workflow_dispatch`
-- Builds per-arch images (`latest-<arch>` and `<sha>-<arch>`)
-- Publishes multi-arch manifests (`latest` and `<sha>`)
-
-## Troubleshooting
-
-- No data: verify `transport`, `network`, and `address` match your live backend
-- Transition mode issues: verify `proxy_profile` and `proxy_endpoint` match your adapter-proxy ENH/ENS listener
-- Endpoint mismatch: verify `http_port`, `graphql_path`, `subscription_path`, `mcp_path`, and alias keys (`port`, `path`)
-- mDNS missing: verify `mdns=true`, multicast availability, and startup log lines
-- Connection errors: verify backend service health, routing, and firewall rules
-- Build module fetch errors: verify token permissions for private `github.com/d3vi1/*` dependencies
-
-## Related links
-
-- Helianthus gateway runtime: https://github.com/d3vi1/helianthus-ebusgateway
-- Helianthus eBUS docs: https://github.com/d3vi1/helianthus-docs-ebus
+- Add-on folder docs: `helianthus/README.md`
 - Operator smoke runbook: `SMOKE_RUNBOOK.md`
-- Issue tracking this README pass: https://github.com/d3vi1/helianthus-ha-addon/issues/28
+- Architecture baseline: `ARCHITECTURE.md`
+- Repository conventions: `CONVENTIONS.md`
+- Agent workflow notes: `AGENT.md`
+
+### Related Helianthus repos/docs
+
+- Gateway runtime: https://github.com/d3vi1/helianthus-ebusgateway
+- Registry/schema layer: https://github.com/d3vi1/helianthus-ebusreg
+- eBUS transport/protocol layer: https://github.com/d3vi1/helianthus-ebusgo
+- HA integration: https://github.com/d3vi1/helianthus-ha-integration
+- eBUS docs hub: https://github.com/d3vi1/helianthus-docs-ebus
+
+### Issue workflow conventions
+
+- Use one issue-focused branch per change (example: `issue-32-readme-refresh`).
+- Keep PR scope aligned to issue acceptance criteria.
+- Include closing keyword in PR body (example: `Fixes #32`).


### PR DESCRIPTION
Fixes #32

## Summary
- refresh README with clear add-on scope boundaries and current maturity note
- add practical quickstart commands for local syntax/docs checks and operator onboarding
- add local smoke configuration examples (baseline and proxy transition)
- add Helianthus dependency-chain context, validation matrix, and link map

## Local validation
- python3 -m json.tool repository.json >/dev/null
- python3 -m json.tool helianthus/config.json >/dev/null
- bash -n helianthus/rootfs/run.sh
- if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi
- python3 scripts/validate_smoke_docs.py
- python3 scripts/smoke_addon_checklist.py --help
- docker --version (availability check; local Docker build skipped because docker is not available in this environment)
