### PR TITLE
addon: bundle adapter proxy + vrc-explorer debug CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,19 +21,19 @@ jobs:
         include:
           - platform: linux/amd64
             arch: amd64
-            base: ghcr.io/home-assistant/amd64-base:3.19
+            base: ghcr.io/home-assistant/amd64-base:3.20
           - platform: linux/arm64
             arch: aarch64
-            base: ghcr.io/home-assistant/aarch64-base:3.19
+            base: ghcr.io/home-assistant/aarch64-base:3.20
           - platform: linux/arm/v7
             arch: armv7
-            base: ghcr.io/home-assistant/armv7-base:3.19
+            base: ghcr.io/home-assistant/armv7-base:3.20
           - platform: linux/arm/v6
             arch: armhf
-            base: ghcr.io/home-assistant/armhf-base:3.19
+            base: ghcr.io/home-assistant/armhf-base:3.20
           - platform: linux/386
             arch: i386
-            base: ghcr.io/home-assistant/i386-base:3.19
+            base: ghcr.io/home-assistant/i386-base:3.20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,6 +62,8 @@ jobs:
             ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-${{ matrix.arch }}
           build-args: |
             EBUSGATEWAY_VERSION=main
+            EBUSADAPTERPROXY_VERSION=main
+            VRCEXPLORER_VERSION=main
             BUILD_FROM=${{ matrix.base }}
           secrets: |
             github_token=${{ secrets.REPO_READ_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 AGENT-local.md
 .DS_Store
+**/__pycache__/

--- a/helianthus/Dockerfile
+++ b/helianthus/Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1.6
 
-ARG BUILD_FROM=ghcr.io/home-assistant/base:3.19
+ARG BUILD_FROM=ghcr.io/home-assistant/base:3.20
+ARG VRCEXPLORER_VERSION=main
 
 FROM --platform=$BUILDPLATFORM golang:1.22-alpine AS builder
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64
 ARG TARGETVARIANT=
 ARG EBUSGATEWAY_VERSION=main
+ARG EBUSADAPTERPROXY_VERSION=main
 
 RUN apk add --no-cache git ca-certificates
 
@@ -18,9 +20,29 @@ RUN --mount=type=secret,id=github_token \
       git config --global url."https://$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \
     fi \
  && GOBIN=/out GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
-    go install github.com/d3vi1/helianthus-ebusgateway/cmd/gateway@${EBUSGATEWAY_VERSION}
+    go install github.com/d3vi1/helianthus-ebusgateway/cmd/gateway@${EBUSGATEWAY_VERSION} \
+ && GOBIN=/out GOOS=$TARGETOS GOARCH=$TARGETARCH GOARM=${TARGETVARIANT#v} \
+    go install github.com/d3vi1/helianthus-ebus-adapter-proxy/cmd/helianthus-ebus-adapter-proxy@${EBUSADAPTERPROXY_VERSION}
+
+FROM --platform=$BUILDPLATFORM python:3.12-alpine AS vrc-explorer
+ARG VRCEXPLORER_VERSION=main
+
+RUN apk add --no-cache git ca-certificates
+
+RUN --mount=type=secret,id=github_token \
+    if [ -f /run/secrets/github_token ]; then \
+      git config --global url."https://$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \
+    fi \
+ && python -m pip install --no-cache-dir --upgrade pip \
+ && python -m pip install --no-cache-dir --target /out/python \
+    "git+https://github.com/d3vi1/helianthus-vrc-explorer@${VRCEXPLORER_VERSION}"
 
 FROM ${BUILD_FROM}
+ARG VRCEXPLORER_VERSION=main
+
+RUN apk add --no-cache python3 ca-certificates
 
 COPY --from=builder /out/gateway /usr/local/bin/helianthus-gateway
+COPY --from=builder /out/helianthus-ebus-adapter-proxy /usr/local/bin/helianthus-ebus-adapter-proxy
+COPY --from=vrc-explorer /out/python /opt/helianthus-vrc-explorer
 COPY rootfs/ /

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -5,8 +5,10 @@ Home Assistant add-on that runs the Helianthus eBUS gateway (GraphQL + MCP).
 ## Status
 
 - Builds and runs `helianthus-ebusgateway`
+- Optionally runs `helianthus-ebus-adapter-proxy` in the same container (s6 service)
 - Exposes GraphQL + MCP over HTTP
 - Advertises `_helianthus-graphql._tcp` via mDNS (optional)
+- Bundles `helianthus_vrc_explorer` in `/usr/bin` for on-device debugging
 
 ## Defaults
 
@@ -18,6 +20,9 @@ Home Assistant add-on that runs the Helianthus eBUS gateway (GraphQL + MCP).
 
 Key options are exposed in `config.json`:
 
+- `adapter_proxy_enabled`: start the local adapter proxy service
+- `adapter_proxy_upstream`: upstream endpoint for the proxy (e.g. `enh://<host>:<port>`)
+- `adapter_proxy_port`: local proxy listen port
 - `transport`: `enh`, `ens`, or `ebusd-tcp`
 - `network`: `tcp` or `unix`
 - `address`: transport address (e.g. `HOST:PORT`)
@@ -36,3 +41,13 @@ For ebusd TCP mode, use `transport=ebusd-tcp`, `network=tcp`, and set `address=<
 
 For transition mode via `helianthus-ebus-adapter-proxy`, set `proxy_profile=enh|ens` and
 `proxy_endpoint=<host:port>` (or full endpoint URI); startup logs emit proxy profile/endpoint markers.
+
+## Debugging tools
+
+This add-on image includes `helianthus_vrc_explorer` at `/usr/bin/helianthus_vrc_explorer`.
+
+It runs with:
+
+```sh
+helianthus_vrc_explorer --help
+```

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
@@ -16,6 +16,12 @@
   },
   "image": "ghcr.io/d3vi1/helianthus-ha-addon",
   "options": {
+    "adapter_proxy_enabled": false,
+    "adapter_proxy_upstream": "",
+    "adapter_proxy_port": 19001,
+    "adapter_proxy_dial_timeout": "3s",
+    "adapter_proxy_read_timeout": "200ms",
+    "adapter_proxy_write_timeout": "2s",
     "transport": "enh",
     "network": "tcp",
     "address": "HOST:PORT",
@@ -36,6 +42,12 @@
     "dial_timeout": "5s"
   },
   "schema": {
+    "adapter_proxy_enabled": "bool",
+    "adapter_proxy_upstream": "str",
+    "adapter_proxy_port": "int",
+    "adapter_proxy_dial_timeout": "str",
+    "adapter_proxy_read_timeout": "str",
+    "adapter_proxy_write_timeout": "str",
     "transport": "list(enh|ens|ebusd-tcp)",
     "network": "list(tcp|unix)",
     "address": "str",

--- a/helianthus/rootfs/etc/services.d/ebus-adapter-proxy/run
+++ b/helianthus/rootfs/etc/services.d/ebus-adapter-proxy/run
@@ -1,0 +1,38 @@
+#!/usr/bin/with-contenv bashio
+
+set -euo pipefail
+
+enabled=$(bashio::config 'adapter_proxy_enabled')
+upstream=$(bashio::config 'adapter_proxy_upstream')
+listen_port=$(bashio::config 'adapter_proxy_port')
+dial_timeout=$(bashio::config 'adapter_proxy_dial_timeout')
+read_timeout=$(bashio::config 'adapter_proxy_read_timeout')
+write_timeout=$(bashio::config 'adapter_proxy_write_timeout')
+
+if ! bashio::var.true "${enabled}"; then
+  bashio::log.info "eBUS adapter proxy: disabled"
+  exec bash -c 'while true; do sleep 3600; done'
+fi
+
+upstream_trimmed=$(printf '%s' "${upstream}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+if [ -z "${upstream_trimmed}" ]; then
+  bashio::exit.nok "adapter_proxy_upstream is required when adapter_proxy_enabled=true"
+fi
+
+if [ -z "${listen_port}" ]; then
+  listen_port=19001
+fi
+
+listen_addr="0.0.0.0:${listen_port}"
+
+bashio::log.info "Starting eBUS adapter proxy"
+bashio::log.info "Listen: ${listen_addr}"
+bashio::log.info "Upstream: (configured)"
+
+exec /usr/local/bin/helianthus-ebus-adapter-proxy \
+  -listen "${listen_addr}" \
+  -upstream "${upstream_trimmed}" \
+  -dial-timeout "${dial_timeout}" \
+  -read-timeout "${read_timeout}" \
+  -write-timeout "${write_timeout}"
+

--- a/helianthus/rootfs/run.sh
+++ b/helianthus/rootfs/run.sh
@@ -20,6 +20,8 @@ broadcast=$(bashio::config 'broadcast')
 read_timeout=$(bashio::config 'read_timeout')
 write_timeout=$(bashio::config 'write_timeout')
 dial_timeout=$(bashio::config 'dial_timeout')
+adapter_proxy_enabled=$(bashio::config 'adapter_proxy_enabled')
+adapter_proxy_port=$(bashio::config 'adapter_proxy_port')
 
 effective_transport="${transport}"
 effective_network="${network}"
@@ -104,6 +106,21 @@ bashio::log.info "GraphQL endpoint: http://${host}:${http_port}${graphql_path}"
 bashio::log.info "Subscriptions endpoint: http://${host}:${http_port}${subscription_path}"
 bashio::log.info "MCP endpoint: http://${host}:${http_port}${mcp_path}"
 bashio::log.info "mDNS: enabled=${mdns} instance=${mdns_instance}"
+
+if bashio::var.true "${adapter_proxy_enabled}"; then
+  if [ -z "${adapter_proxy_port}" ]; then
+    adapter_proxy_port=19001
+  fi
+
+  bashio::log.info "Waiting for eBUS adapter proxy on 127.0.0.1:${adapter_proxy_port}"
+  for _ in $(seq 1 50); do
+    if (echo >/dev/tcp/127.0.0.1/${adapter_proxy_port}) >/dev/null 2>&1; then
+      bashio::log.info "eBUS adapter proxy is reachable"
+      break
+    fi
+    sleep 0.1
+  done
+fi
 
 exec /usr/local/bin/helianthus-gateway \
   -transport "${effective_transport}" \

--- a/helianthus/rootfs/usr/bin/helianthus_vrc_explorer
+++ b/helianthus/rootfs/usr/bin/helianthus_vrc_explorer
@@ -1,0 +1,6 @@
+#!/usr/bin/with-contenv bashio
+
+set -euo pipefail
+
+export PYTHONPATH="/opt/helianthus-vrc-explorer${PYTHONPATH:+:${PYTHONPATH}}"
+exec python3 -m helianthus_vrc_explorer "$@"


### PR DESCRIPTION
Closes #34.

## What
- Add-on image now bundles:
  - `/usr/local/bin/helianthus-ebus-adapter-proxy` + s6 service (enable via `adapter_proxy_enabled` + `adapter_proxy_upstream`).
  - `/usr/bin/helianthus_vrc_explorer` (debug CLI wrapper).
- Docker build includes the `helianthus-vrc-explorer` Python package under `/opt/helianthus-vrc-explorer`.
- Base images bumped to `:3.20` so the runtime has Python 3.12 for `helianthus_vrc_explorer`.

## How to use
- Enable proxy in add-on config:
  - `adapter_proxy_enabled: true`
  - `adapter_proxy_upstream: "enh://<host>:<port>"` (or `ens://...`)
- Run explorer inside the add-on container:
  - `helianthus_vrc_explorer --help`

## CI
- Multi-arch build args now include `EBUSADAPTERPROXY_VERSION` and `VRCEXPLORER_VERSION`.
