### PR TITLE
ci: publish semver image tags for HA updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Read add-on version
+        id: addon
+        run: |
+          set -euo pipefail
+          echo "version=$(jq -r '.version' helianthus/config.json)" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -60,6 +66,7 @@ jobs:
           tags: |
             ghcr.io/d3vi1/helianthus-ha-addon:latest-${{ matrix.arch }}
             ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-${{ matrix.arch }}
+            ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }}-${{ matrix.arch }}
           build-args: |
             EBUSGATEWAY_VERSION=main
             EBUSADAPTERPROXY_VERSION=main
@@ -72,6 +79,15 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read add-on version
+        id: addon
+        run: |
+          set -euo pipefail
+          echo "version=$(jq -r '.version' helianthus/config.json)" >> "$GITHUB_OUTPUT"
+
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -96,3 +112,10 @@ jobs:
             ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-armv7 \
             ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-armhf \
             ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-i386
+          docker buildx imagetools create \
+            -t ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }} \
+            ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }}-amd64 \
+            ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }}-aarch64 \
+            ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }}-armv7 \
+            ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }}-armhf \
+            ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }}-i386


### PR DESCRIPTION
Fixes #36.

Home Assistant Supervisor pulls add-on images by version tag (helianthus/config.json version). This updates the workflow to publish matching :<version> and :<version>-<arch> tags, alongside the existing latest/sha tags.