### PR TITLE
chore(addon): bump version to 0.3.1

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],


### PR DESCRIPTION
Fixes #38.

Bumps add-on version so Supervisor pulls a fresh image (incl. latest helianthus-vrc-explorer on main at build time).