### PR TITLE
Bump add-on version to 0.3.4

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],


### PR DESCRIPTION
Closes #44.

- Bumps `helianthus/config.json` version to force CI rebuild/publish.
- Picks up the fixed `helianthus-ebus-adapter-proxy` entrypoint from d3vi1/helianthus-ebus-adapter-proxy@main.

@chatgpt-codex-connector