### PR TITLE
Start Helianthus gateway service

### DIFF
--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -1,0 +1,5 @@
+#!/usr/bin/with-contenv bashio
+
+set -euo pipefail
+
+exec /run.sh


### PR DESCRIPTION
Adds an s6 service (`helianthus-gateway`) that execs `/run.sh`, so the gateway runs when `startup=services` (alongside the adapter proxy).

Fixes #46.