### PR TITLE
Bump add-on version to 0.3.6

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],


### PR DESCRIPTION
Bumps the add-on version so HA pulls an image that includes the latest helianthus-ebusgateway startup scan behavior.

Fixes #50.