### PR TITLE
chore(addon): bump version to 0.3.7

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],


### PR DESCRIPTION
Fixes #52.

Force a new add-on image build so HA pulls the latest `helianthus-ebusgateway@main` (startup scan timeout fix).