### PR TITLE
ci: stop publishing sha-tagged images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,6 @@ jobs:
           platforms: ${{ matrix.platform }}
           tags: |
             ghcr.io/d3vi1/helianthus-ha-addon:latest-${{ matrix.arch }}
-            ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-${{ matrix.arch }}
             ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }}-${{ matrix.arch }}
           build-args: |
             EBUSGATEWAY_VERSION=main
@@ -105,13 +104,6 @@ jobs:
             ghcr.io/d3vi1/helianthus-ha-addon:latest-armv7 \
             ghcr.io/d3vi1/helianthus-ha-addon:latest-armhf \
             ghcr.io/d3vi1/helianthus-ha-addon:latest-i386
-          docker buildx imagetools create \
-            -t ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }} \
-            ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-amd64 \
-            ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-aarch64 \
-            ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-armv7 \
-            ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-armhf \
-            ghcr.io/d3vi1/helianthus-ha-addon:${{ github.sha }}-i386
           docker buildx imagetools create \
             -t ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }} \
             ghcr.io/d3vi1/helianthus-ha-addon:${{ steps.addon.outputs.version }}-amd64 \


### PR DESCRIPTION
Fixes #54.

Work around intermittent GHCR 403s observed when pushing the per-commit sha tag for i386 by only publishing latest + semantic version tags (per-arch + multi-arch manifests).