### PR TITLE
chore(addon): bump version to 0.3.8

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],


### PR DESCRIPTION
Fixes #56.

Force a new image build so HA pulls the latest gateway main (startup scan timeout bump).