### PR TITLE
chore(addon): bump version to 0.3.9

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],


### PR DESCRIPTION
Bump add-on version to `0.3.9` to trigger a new image build with the latest gateway/ebusgo ENH response parsing fix.

Fixes #58.
