### PR TITLE
chore(addon): bump version to 0.3.12

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,9 +1,15 @@
 {
   "name": "Helianthus",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
-  "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
+  "arch": [
+    "aarch64",
+    "amd64",
+    "armhf",
+    "armv7",
+    "i386"
+  ],
   "startup": "services",
   "boot": "auto",
   "init": false,


### PR DESCRIPTION
Fixes #60.

Bumps add-on version so Supervisor pulls a fresh image (needed to pick up latest adapter-proxy changes).

Local checks:
- JSON syntax OK
- terminology gate OK
- smoke runbook validator OK

Note: GitHub Actions + Codex reviews are currently unavailable; build+deploy will be done manually on the HA host.