### PR TITLE
fix(addon): buildable without buildx on HA host

### DIFF
--- a/helianthus/Dockerfile
+++ b/helianthus/Dockerfile
@@ -3,7 +3,7 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/base:3.20
 ARG VRCEXPLORER_VERSION=main
 
-FROM --platform=$TARGETPLATFORM golang:1.22-alpine AS builder
+FROM golang:1.22-alpine AS builder
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG EBUSGATEWAY_VERSION=main
@@ -14,24 +14,16 @@ RUN apk add --no-cache git ca-certificates
 ENV CGO_ENABLED=0
 ENV GOPRIVATE=github.com/d3vi1/*
 
-RUN --mount=type=secret,id=github_token \
-    if [ -f /run/secrets/github_token ]; then \
-      git config --global url."https://$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \
-    fi \
- && if [ "${TARGETARCH}" = "arm" ] && [ -n "${TARGETVARIANT}" ]; then export GOARM="${TARGETVARIANT#v}"; fi \
+RUN if [ "${TARGETARCH}" = "arm" ] && [ -n "${TARGETVARIANT}" ]; then export GOARM="${TARGETVARIANT#v}"; fi \
  && GOBIN=/out go install github.com/d3vi1/helianthus-ebusgateway/cmd/gateway@${EBUSGATEWAY_VERSION} \
  && GOBIN=/out go install github.com/d3vi1/helianthus-ebus-adapter-proxy/cmd/helianthus-ebus-adapter-proxy@${EBUSADAPTERPROXY_VERSION}
 
-FROM --platform=$BUILDPLATFORM python:3.12-alpine AS vrc-explorer
+FROM python:3.12-alpine AS vrc-explorer
 ARG VRCEXPLORER_VERSION=main
 
 RUN apk add --no-cache git ca-certificates
 
-RUN --mount=type=secret,id=github_token \
-    if [ -f /run/secrets/github_token ]; then \
-      git config --global url."https://$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \
-    fi \
- && python -m pip install --no-cache-dir --upgrade pip \
+RUN python -m pip install --no-cache-dir --upgrade pip \
  && python -m pip install --no-cache-dir --target /out/python \
     "git+https://github.com/d3vi1/helianthus-vrc-explorer@${VRCEXPLORER_VERSION}"
 


### PR DESCRIPTION
Fixes #62.

Problem: HA host docker is using the legacy builder (no buildx), so the add-on Dockerfile fails on `FROM --platform=$TARGETPLATFORM` and BuildKit secret mounts.

Change:
- Remove `--platform=` directives and BuildKit-only secret mounts.
- Keep behavior identical for public repos; GitHub Actions builds still work.

Local checks:
- JSON syntax OK
- terminology gate OK
- smoke runbook validator OK

Next:
- Sync updated add-on sources to HA
- Build+push `ghcr.io/d3vi1/helianthus-ha-addon:0.3.12` from HA host
- Re-run ebusd scan via proxy