### PR TITLE
fix(addon): restore BuildKit secrets

### DIFF
--- a/helianthus/Dockerfile
+++ b/helianthus/Dockerfile
@@ -3,7 +3,7 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/base:3.20
 ARG VRCEXPLORER_VERSION=main
 
-FROM golang:1.22-alpine AS builder
+FROM --platform=$TARGETPLATFORM golang:1.22-alpine AS builder
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG EBUSGATEWAY_VERSION=main
@@ -14,16 +14,24 @@ RUN apk add --no-cache git ca-certificates
 ENV CGO_ENABLED=0
 ENV GOPRIVATE=github.com/d3vi1/*
 
-RUN if [ "${TARGETARCH}" = "arm" ] && [ -n "${TARGETVARIANT}" ]; then export GOARM="${TARGETVARIANT#v}"; fi \
+RUN --mount=type=secret,id=github_token \
+    if [ -f /run/secrets/github_token ]; then \
+      git config --global url."https://$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \
+    fi \
+ && if [ "${TARGETARCH}" = "arm" ] && [ -n "${TARGETVARIANT}" ]; then export GOARM="${TARGETVARIANT#v}"; fi \
  && GOBIN=/out go install github.com/d3vi1/helianthus-ebusgateway/cmd/gateway@${EBUSGATEWAY_VERSION} \
  && GOBIN=/out go install github.com/d3vi1/helianthus-ebus-adapter-proxy/cmd/helianthus-ebus-adapter-proxy@${EBUSADAPTERPROXY_VERSION}
 
-FROM python:3.12-alpine AS vrc-explorer
+FROM --platform=$BUILDPLATFORM python:3.12-alpine AS vrc-explorer
 ARG VRCEXPLORER_VERSION=main
 
 RUN apk add --no-cache git ca-certificates
 
-RUN python -m pip install --no-cache-dir --upgrade pip \
+RUN --mount=type=secret,id=github_token \
+    if [ -f /run/secrets/github_token ]; then \
+      git config --global url."https://$(cat /run/secrets/github_token)@github.com/".insteadOf "https://github.com/"; \
+    fi \
+ && python -m pip install --no-cache-dir --upgrade pip \
  && python -m pip install --no-cache-dir --target /out/python \
     "git+https://github.com/d3vi1/helianthus-vrc-explorer@${VRCEXPLORER_VERSION}"
 


### PR DESCRIPTION
Fixes #64.

We need BuildKit secret mounts for a GitHub token so `go install github.com/d3vi1/helianthus-ebusgateway@main` works without embedding credentials in image layers.

This restores the previous BuildKit-only `RUN --mount=type=secret,id=github_token` blocks (and `--platform` stage hints).

Local checks:
- JSON syntax OK
- terminology gate OK
- smoke runbook validator OK

Next:
- Install buildx on HA host (already done)
- Build+push `ghcr.io/d3vi1/helianthus-ha-addon:0.3.12` with `--secret id=github_token`
- Update add-on and re-run ebusd scan through proxy