### PR TITLE
chore(addon): bump version to 0.3.13

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
Fixes #66.

Bumps the add-on version to force a Supervisor pull of a freshly rebuilt image (clean s6 services tree).