### PR TITLE
helianthus add-on: 0.3.14

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
Bump add-on version to 0.3.14 to publish a new image build (pulls latest helianthus-ebus-adapter-proxy fixes).