### PR TITLE
addon: bump to 0.3.15

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
Bump add-on version to 0.3.15 so Home Assistant Supervisor will pull a fresh image after the adapter-proxy ebusd-compat fixes.
