### PR TITLE
addon: bump to 0.3.16

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
Bump add-on version to 0.3.16 to ship the latest adapter-proxy ebusd-compat fixes.
