### PR TITLE
addon: bump to 0.3.24 (adapter-proxy lock fix)

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [
@@ -23,6 +23,7 @@
   "image": "ghcr.io/d3vi1/helianthus-ha-addon",
   "options": {
     "adapter_proxy_enabled": false,
+    "adapter_proxy_debug": false,
     "adapter_proxy_upstream": "",
     "adapter_proxy_port": 19001,
     "adapter_proxy_dial_timeout": "3s",
@@ -49,6 +50,7 @@
   },
   "schema": {
     "adapter_proxy_enabled": "bool",
+    "adapter_proxy_debug": "bool",
     "adapter_proxy_upstream": "str",
     "adapter_proxy_port": "int",
     "adapter_proxy_dial_timeout": "str",

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/rootfs/etc/services.d/ebus-adapter-proxy/run
+++ b/helianthus/rootfs/etc/services.d/ebus-adapter-proxy/run
@@ -31,9 +31,9 @@ bashio::log.info "Listen: ${listen_addr}"
 bashio::log.info "Upstream: (configured)"
 
 extra_args=()
-if bashio::var.true "${debug}"; then
-  extra_args+=("-debug")
-fi
+# Force debug logs on for now. This add-on is used primarily for live debugging
+# and will be switched back to config-controlled once the proxy is stable.
+extra_args+=("-debug")
 
 exec /usr/local/bin/helianthus-ebus-adapter-proxy \
   -listen "${listen_addr}" \

--- a/helianthus/rootfs/etc/services.d/ebus-adapter-proxy/run
+++ b/helianthus/rootfs/etc/services.d/ebus-adapter-proxy/run
@@ -31,9 +31,9 @@ bashio::log.info "Listen: ${listen_addr}"
 bashio::log.info "Upstream: (configured)"
 
 extra_args=()
-# Force debug logs on for now. This add-on is used primarily for live debugging
-# and will be switched back to config-controlled once the proxy is stable.
-extra_args+=("-debug")
+if bashio::var.true "${debug}"; then
+  extra_args+=("-debug")
+fi
 
 exec /usr/local/bin/helianthus-ebus-adapter-proxy \
   -listen "${listen_addr}" \

--- a/helianthus/rootfs/etc/services.d/ebus-adapter-proxy/run
+++ b/helianthus/rootfs/etc/services.d/ebus-adapter-proxy/run
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 enabled=$(bashio::config 'adapter_proxy_enabled')
+debug=$(bashio::config 'adapter_proxy_debug')
 upstream=$(bashio::config 'adapter_proxy_upstream')
 listen_port=$(bashio::config 'adapter_proxy_port')
 dial_timeout=$(bashio::config 'adapter_proxy_dial_timeout')
@@ -29,10 +30,15 @@ bashio::log.info "Starting eBUS adapter proxy"
 bashio::log.info "Listen: ${listen_addr}"
 bashio::log.info "Upstream: (configured)"
 
+extra_args=()
+if bashio::var.true "${debug}"; then
+  extra_args+=("-debug")
+fi
+
 exec /usr/local/bin/helianthus-ebus-adapter-proxy \
   -listen "${listen_addr}" \
   -upstream "${upstream_trimmed}" \
   -dial-timeout "${dial_timeout}" \
   -read-timeout "${read_timeout}" \
-  -write-timeout "${write_timeout}"
-
+  -write-timeout "${write_timeout}" \
+  "${extra_args[@]}"


### PR DESCRIPTION
This bumps the Helianthus HA add-on to v0.3.24 and updates the bundled ebus-adapter-proxy to fix ENH multiplexing.

Notable:
- ebus-adapter-proxy: releases bus ownership on upstream idle SYN after SEND activity (prevents gateway from starving ebusd).
- helianthus_vrc_explorer is bundled in /usr/bin for debugging.
- Build workflow passes per-platform BUILD_FROM to keep multi-arch builds correct.

Operationally verified on HA (aarch64) by building/pushing the image and upgrading the local add-on.