### PR TITLE
addon: configurable gateway scan timeout

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.24",
+  "version": "0.3.25",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [
@@ -44,6 +44,7 @@
     "mdns": true,
     "mdns_instance": "helianthus",
     "broadcast": false,
+    "scan_request_timeout": "400ms",
     "read_timeout": "5s",
     "write_timeout": "5s",
     "dial_timeout": "5s"
@@ -71,6 +72,7 @@
     "mdns": "bool",
     "mdns_instance": "str",
     "broadcast": "bool",
+    "scan_request_timeout": "str",
     "read_timeout": "str",
     "write_timeout": "str",
     "dial_timeout": "str"

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -17,6 +17,7 @@ mcp_path=$(bashio::config 'mcp_path')
 mdns=$(bashio::config 'mdns')
 mdns_instance=$(bashio::config 'mdns_instance')
 broadcast=$(bashio::config 'broadcast')
+scan_request_timeout=$(bashio::config 'scan_request_timeout')
 read_timeout=$(bashio::config 'read_timeout')
 write_timeout=$(bashio::config 'write_timeout')
 dial_timeout=$(bashio::config 'dial_timeout')
@@ -122,10 +123,15 @@ if bashio::var.true "${adapter_proxy_enabled}"; then
   done
 fi
 
+if [ -z "${scan_request_timeout}" ]; then
+  scan_request_timeout="400ms"
+fi
+
 exec /usr/local/bin/helianthus-gateway \
   -transport "${effective_transport}" \
   -network "${effective_network}" \
   -address "${effective_address}" \
+  -scan-request-timeout "${scan_request_timeout}" \
   -http-addr "${http_addr}" \
   -graphql-path "${graphql_path}" \
   -subscription-path "${subscription_path}" \


### PR DESCRIPTION
- Add add-on option `scan_request_timeout` (duration string).
- Pass `-scan-request-timeout` to helianthus-gateway.
- Bump add-on version to 0.3.25.

Fixes startup scan registering 0 devices on real ENH-over-TCP where ident RTT can exceed 150ms.