### PR TITLE
addon: set gateway source_addr (default 0x31)

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [
@@ -44,6 +44,7 @@
     "mdns": true,
     "mdns_instance": "helianthus",
     "broadcast": false,
+    "source_addr": "0x31",
     "scan_request_timeout": "400ms",
     "read_timeout": "5s",
     "write_timeout": "5s",
@@ -72,6 +73,7 @@
     "mdns": "bool",
     "mdns_instance": "str",
     "broadcast": "bool",
+    "source_addr": "str",
     "scan_request_timeout": "str",
     "read_timeout": "str",
     "write_timeout": "str",

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -17,6 +17,7 @@ mcp_path=$(bashio::config 'mcp_path')
 mdns=$(bashio::config 'mdns')
 mdns_instance=$(bashio::config 'mdns_instance')
 broadcast=$(bashio::config 'broadcast')
+source_addr=$(bashio::config 'source_addr')
 scan_request_timeout=$(bashio::config 'scan_request_timeout')
 read_timeout=$(bashio::config 'read_timeout')
 write_timeout=$(bashio::config 'write_timeout')
@@ -127,10 +128,16 @@ if [ -z "${scan_request_timeout}" ]; then
   scan_request_timeout="400ms"
 fi
 
+source_addr_args=()
+if [ -n "${source_addr}" ]; then
+  source_addr_args=(-source-addr "${source_addr}")
+fi
+
 exec /usr/local/bin/helianthus-gateway \
   -transport "${effective_transport}" \
   -network "${effective_network}" \
   -address "${effective_address}" \
+  "${source_addr_args[@]}" \
   -scan-request-timeout "${scan_request_timeout}" \
   -http-addr "${http_addr}" \
   -graphql-path "${graphql_path}" \


### PR DESCRIPTION
- Add add-on option `source_addr` and pass it to helianthus-gateway (`-source-addr`).
- Default to `0x31` to match ebusd/real bus arbitration behavior.
- Bump add-on version to 0.3.26.