### PR TITLE
chore(addon): bump version to 0.3.27

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.27",
+  "version": "0.3.28",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.29",
+  "version": "0.3.30",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
Bumps the HA add-on version to publish a fresh image with updated gateway scan diagnostics.