### PR TITLE
chore(addon): bump version to 0.3.33

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
Fixes #75.

Bumps the add-on version so HA can pull the new image tag `0.3.33`.
