### PR TITLE
chore(addon): bump version to 0.3.34

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
Fixes #77.

Bumps the add-on version for a republished image built with pinned component SHAs (avoids stale BuildKit cache when using `@main`).
