### PR TITLE
meta01: local CI entrypoint + redact private IPs in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,7 @@ helianthus-ebusgo -> helianthus-ebusreg -> helianthus-ebusgateway -> helianthus-
 ```bash
 git clone https://github.com/d3vi1/helianthus-ha-addon.git
 cd helianthus-ha-addon
-python3 -m json.tool repository.json >/dev/null
-python3 -m json.tool helianthus/config.json >/dev/null
-bash -n helianthus/rootfs/run.sh
-if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi
-python3 scripts/validate_smoke_docs.py
+./scripts/ci_local.sh
 python3 scripts/smoke_addon_checklist.py --help
 ```
 
@@ -65,7 +61,7 @@ Then install **Helianthus** from the Add-on Store and open add-on configuration.
 ```yaml
 transport: ebusd-tcp
 network: tcp
-address: 192.168.100.2:9999
+address: 203.0.113.10:9999
 proxy_profile: disabled
 proxy_endpoint: ""
 http_port: 8080
@@ -80,7 +76,7 @@ mdns: true
 ```yaml
 transport: enh
 network: tcp
-address: 192.168.100.2:9999
+address: 203.0.113.10:9999
 proxy_profile: enh
 proxy_endpoint: 127.0.0.1:19001
 http_port: 8080
@@ -106,7 +102,7 @@ Deterministic smoke checklist from add-on logs:
 
 ```bash
 ha addons logs helianthus > /tmp/helianthus-addon.log
-python3 scripts/smoke_addon_checklist.py --log-file /tmp/helianthus-addon.log --address 192.168.100.2:9999
+python3 scripts/smoke_addon_checklist.py --log-file /tmp/helianthus-addon.log --address 203.0.113.10:9999
 ```
 
 For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
@@ -117,7 +113,6 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 |---|---|
 | JSON syntax | `python3 -m json.tool repository.json >/dev/null` |
 | add-on config syntax | `python3 -m json.tool helianthus/config.json >/dev/null` |
-| shell syntax | `bash -n helianthus/rootfs/run.sh` |
 | terminology gate (CI parity) | `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi` |
 | smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
 | smoke checker CLI | `python3 scripts/smoke_addon_checklist.py --help` |

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "==> validate JSON syntax"
+found=0
+while IFS= read -r file; do
+  [ -z "${file}" ] && continue
+  found=1
+  python3 -m json.tool "${file}" >/dev/null
+  echo "OK: ${file}"
+done < <(git ls-files '*.json')
+if [ "${found}" -eq 0 ]; then
+  echo "No JSON files found."
+fi
+
+echo "==> validate shell syntax"
+found=0
+while IFS= read -r file; do
+  [ -z "${file}" ] && continue
+  found=1
+  bash -n "${file}"
+  echo "OK: ${file}"
+done < <(git ls-files '*.sh')
+if [ "${found}" -eq 0 ]; then
+  echo "No shell files found."
+fi
+
+echo "==> terminology gate"
+if git grep -nIwiE 'm[a]ster|s[l]ave'; then
+  echo "Found legacy terminology in tracked files."
+  exit 1
+fi
+
+echo "==> validate smoke runbook structure"
+python3 scripts/validate_smoke_docs.py
+
+echo "==> private IPv4 address gate (docs must use placeholders)"
+python3 - <<'PY'
+from __future__ import annotations
+
+import ipaddress
+import pathlib
+import re
+import subprocess
+import sys
+
+md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
+ipv4_re = re.compile(r"\\b(?:(?:\\d{1,3})\\.){3}(?:\\d{1,3})\\b")
+
+def is_private(ip: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip)
+    except ValueError:
+        return False
+    return addr.version == 4 and (addr.is_private or addr.is_link_local)
+
+failed = False
+
+for file_path in md_files:
+    text = pathlib.Path(file_path).read_text(encoding="utf-8")
+    for match in ipv4_re.finditer(text):
+        ip = match.group(0)
+        if not is_private(ip):
+            continue
+        line = text.count("\n", 0, match.start()) + 1
+        print(f"{file_path}:{line}: private IPv4 address found (use a placeholder)", file=sys.stderr)
+        failed = True
+
+if failed:
+    sys.exit(1)
+print("Private IPv4 gate passed.")
+PY
+


### PR DESCRIPTION
Fixes #79.

Adds `scripts/ci_local.sh` (JSON + docs validation, terminology gate, private IPv4 leak gate) and replaces private IPs in README examples with placeholders.