### PR TITLE
Build: resolve VRC Explorer main to pinned commit SHA (#85)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,11 @@ jobs:
         id: vrc
         run: |
           set -euo pipefail
-          ref="$(git ls-remote https://github.com/d3vi1/helianthus-vrc-explorer.git refs/heads/main | awk '{print $1}')"
+          remote_url="https://github.com/d3vi1/helianthus-vrc-explorer.git"
+          if [ -n "${{ secrets.REPO_READ_TOKEN }}" ]; then
+            remote_url="https://x-access-token:${{ secrets.REPO_READ_TOKEN }}@github.com/d3vi1/helianthus-vrc-explorer.git"
+          fi
+          ref="$(git ls-remote "${remote_url}" refs/heads/main | awk '{print $1}')"
           if [ -z "${ref}" ]; then
             echo "failed to resolve helianthus-vrc-explorer main ref" >&2
             exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,18 @@ jobs:
           set -euo pipefail
           echo "version=$(jq -r '.version' helianthus/config.json)" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve helianthus-vrc-explorer ref
+        id: vrc
+        run: |
+          set -euo pipefail
+          ref="$(git ls-remote https://github.com/d3vi1/helianthus-vrc-explorer.git refs/heads/main | awk '{print $1}')"
+          if [ -z "${ref}" ]; then
+            echo "failed to resolve helianthus-vrc-explorer main ref" >&2
+            exit 1
+          fi
+          echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+          echo "Resolved helianthus-vrc-explorer main to ${ref}"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -69,7 +81,7 @@ jobs:
           build-args: |
             EBUSGATEWAY_VERSION=main
             EBUSADAPTERPROXY_VERSION=main
-            VRCEXPLORER_VERSION=main
+            VRCEXPLORER_VERSION=${{ steps.vrc.outputs.ref }}
             BUILD_FROM=${{ matrix.base }}
           secrets: |
             github_token=${{ secrets.REPO_READ_TOKEN }}

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -55,6 +55,7 @@ For transition mode via `helianthus-ebus-adapter-proxy`, set `proxy_profile=enh|
 ## Debugging tools
 
 This add-on image includes `helianthus_vrc_explorer` at `/usr/bin/helianthus_vrc_explorer`.
+CI builds resolve `helianthus-vrc-explorer` `main` to a concrete commit SHA at build time and install that pinned revision in the image.
 
 It runs with:
 


### PR DESCRIPTION
## Summary
- resolve `helianthus-vrc-explorer` `main` to a concrete commit SHA in build workflow
- pass resolved SHA into Docker build arg `VRCEXPLORER_VERSION`
- document pinned-at-build behavior in add-on README

## Validation
- `./scripts/ci_local.sh`

Closes #85