### PR TITLE
MCP-10-401: add-on parity readiness gate checks

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -58,3 +58,9 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/validate_smoke_docs.py
+
+      - name: Validate gateway parity gate artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 | add-on config syntax | `python3 -m json.tool helianthus/config.json >/dev/null` |
 | terminology gate (CI parity) | `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi` |
 | smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
+| gateway parity gate readiness | `python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | smoke checker CLI | `python3 scripts/smoke_addon_checklist.py --help` |
 
 ## Link Map

--- a/scripts/check_gateway_parity_gate.py
+++ b/scripts/check_gateway_parity_gate.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate gateway parity artifact readiness markers for add-on rollout gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+REQUIRED_SOURCE_REPO = "d3vi1/helianthus-ebusgateway"
+REQUIRED_GATES = ("parity_contract", "tool_classification")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate gateway parity gate artifact")
+    parser.add_argument("--artifact", required=True, help="Path to parity artifact JSON")
+    parser.add_argument(
+        "--source-repo",
+        default=REQUIRED_SOURCE_REPO,
+        help="Expected gateway source repository",
+    )
+    return parser.parse_args()
+
+
+def load_artifact(path: str) -> dict[str, Any]:
+    artifact_path = Path(path)
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("artifact root must be a JSON object")
+    return payload
+
+
+def validate_artifact(payload: dict[str, Any], expected_source_repo: str) -> list[str]:
+    errors: list[str] = []
+
+    source_repo = str(payload.get("source_repo", "")).strip()
+    if source_repo != expected_source_repo:
+        errors.append(
+            f"source_repo mismatch: got={source_repo or '<empty>'} expected={expected_source_repo}"
+        )
+
+    if not str(payload.get("source_ref", "")).strip():
+        errors.append("source_ref missing")
+    if not str(payload.get("generated_at", "")).strip():
+        errors.append("generated_at missing")
+
+    gates = payload.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("gates missing or invalid")
+        return errors
+
+    for gate_name in REQUIRED_GATES:
+        gate = gates.get(gate_name)
+        if not isinstance(gate, dict):
+            errors.append(f"gate {gate_name} missing")
+            continue
+        status = str(gate.get("status", "")).strip().lower()
+        if status != "pass":
+            errors.append(f"gate {gate_name} status is {status or '<empty>'}, expected pass")
+
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = load_artifact(args.artifact)
+    except FileNotFoundError:
+        print(f"Gateway parity gate: FAIL (artifact missing: {args.artifact})")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Gateway parity gate: FAIL (invalid json: {exc})")
+        return 1
+    except ValueError as exc:
+        print(f"Gateway parity gate: FAIL ({exc})")
+        return 1
+
+    errors = validate_artifact(payload, args.source_repo)
+    if errors:
+        print(f"Gateway parity gate: FAIL ({'; '.join(errors)})")
+        return 1
+
+    print("Gateway parity gate: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -37,6 +37,9 @@ fi
 echo "==> validate smoke runbook structure"
 python3 scripts/validate_smoke_docs.py
 
+echo "==> gateway parity gate readiness"
+python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json
+
 echo "==> private IPv4 address gate (docs must use placeholders)"
 python3 - <<'PY'
 from __future__ import annotations

--- a/scripts/fixtures/gateway_parity_artifact_pass.json
+++ b/scripts/fixtures/gateway_parity_artifact_pass.json
@@ -1,0 +1,15 @@
+{
+  "source_repo": "d3vi1/helianthus-ebusgateway",
+  "source_ref": "refs/heads/mcpfirst-cruise-control",
+  "generated_at": "2026-02-24T00:00:00Z",
+  "gates": {
+    "parity_contract": {
+      "status": "pass",
+      "details": "mcp parity_contract_test passed"
+    },
+    "tool_classification": {
+      "status": "pass",
+      "details": "mcp tool_classification_test passed"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add gateway parity artifact readiness validator for add-on rollout checks (`scripts/check_gateway_parity_gate.py`)
- add deterministic pass fixture for gate markers (`scripts/fixtures/gateway_parity_artifact_pass.json`)
- integrate parity readiness gate into validation flows:
  - local CI script (`scripts/ci_local.sh`)
  - PR workflow (`.github/workflows/pr-ci.yml`)
- document readiness command in README

## Validation
- ./scripts/ci_local.sh

Fixes #87
