### PR TITLE
MCP-10-402: rollout guardrails (consumers after parity)

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -64,3 +64,9 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json
+
+      - name: Validate rollout guardrails
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,3 +12,8 @@ This repository is a minimal Home Assistant add-on skeleton for Helianthus. Ther
 ## Runtime
 
 The container runs a placeholder command that logs a startup message and stays alive. No ports, services, or integrations are configured at this stage.
+
+## Consumer Rollout Guardrails
+
+Add-on consumer expansion is controlled by `helianthus/rollout_guardrails.json`.
+Default stage is `pre_parity`, which blocks consumer expansion until parity completion gates are approved.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 | terminology gate (CI parity) | `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi` |
 | smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
 | gateway parity gate readiness | `python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
+| rollout guardrails | `python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | smoke checker CLI | `python3 scripts/smoke_addon_checklist.py --help` |
 
 ## Link Map

--- a/helianthus/rollout_guardrails.json
+++ b/helianthus/rollout_guardrails.json
@@ -1,0 +1,8 @@
+{
+  "stage": "pre_parity",
+  "allow_consumer_expansion": false,
+  "required_gateway_gates": [
+    "parity_contract",
+    "tool_classification"
+  ]
+}

--- a/scripts/check_rollout_guardrails.py
+++ b/scripts/check_rollout_guardrails.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate add-on rollout guardrails against gateway parity artifact status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import check_gateway_parity_gate as parity
+
+VALID_STAGES = {"pre_parity", "post_parity"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate add-on rollout guardrails")
+    parser.add_argument(
+        "--guardrail",
+        default="helianthus/rollout_guardrails.json",
+        help="Path to add-on rollout guardrail config",
+    )
+    parser.add_argument(
+        "--artifact",
+        default="scripts/fixtures/gateway_parity_artifact_pass.json",
+        help="Path to gateway parity artifact JSON",
+    )
+    parser.add_argument(
+        "--source-repo",
+        default=parity.REQUIRED_SOURCE_REPO,
+        help="Expected gateway source repository",
+    )
+    return parser.parse_args()
+
+
+def load_guardrail(path: str) -> dict:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("guardrail config must be a JSON object")
+    return payload
+
+
+def validate_guardrails(guardrail: dict, artifact: dict, source_repo: str) -> list[str]:
+    errors: list[str] = []
+
+    stage = str(guardrail.get("stage", "")).strip()
+    if stage not in VALID_STAGES:
+        errors.append(f"invalid stage: {stage or '<empty>'}")
+        return errors
+
+    allow_consumer_expansion = bool(guardrail.get("allow_consumer_expansion", False))
+
+    required_gates = guardrail.get("required_gateway_gates", list(parity.REQUIRED_GATES))
+    if not isinstance(required_gates, list) or not required_gates:
+        errors.append("required_gateway_gates missing or invalid")
+        return errors
+
+    for gate in required_gates:
+        gate_name = str(gate).strip()
+        if not gate_name:
+            errors.append("required_gateway_gates contains empty value")
+            continue
+        if gate_name not in parity.REQUIRED_GATES:
+            errors.append(f"unsupported required gate: {gate_name}")
+
+    if errors:
+        return errors
+
+    if stage == "pre_parity":
+        if allow_consumer_expansion:
+            errors.append("pre_parity stage forbids allow_consumer_expansion=true")
+        return errors
+
+    if not allow_consumer_expansion:
+        errors.append("post_parity stage requires allow_consumer_expansion=true")
+
+    parity_errors = parity.validate_artifact(artifact, source_repo)
+    if parity_errors:
+        errors.extend(parity_errors)
+        return errors
+
+    gates = artifact.get("gates") if isinstance(artifact.get("gates"), dict) else {}
+    for gate in required_gates:
+        gate_name = str(gate)
+        gate_payload = gates.get(gate_name, {})
+        status = str(gate_payload.get("status", "")).strip().lower()
+        if status != "pass":
+            errors.append(f"required gate {gate_name} is not pass")
+
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        guardrail = load_guardrail(args.guardrail)
+    except FileNotFoundError:
+        print(f"Rollout guardrails: FAIL (guardrail missing: {args.guardrail})")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Rollout guardrails: FAIL (invalid guardrail json: {exc})")
+        return 1
+    except ValueError as exc:
+        print(f"Rollout guardrails: FAIL ({exc})")
+        return 1
+
+    try:
+        artifact = parity.load_artifact(args.artifact)
+    except FileNotFoundError:
+        print(f"Rollout guardrails: FAIL (parity artifact missing: {args.artifact})")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Rollout guardrails: FAIL (invalid parity artifact json: {exc})")
+        return 1
+    except ValueError as exc:
+        print(f"Rollout guardrails: FAIL ({exc})")
+        return 1
+
+    errors = validate_guardrails(guardrail, artifact, args.source_repo)
+    if errors:
+        print(f"Rollout guardrails: FAIL ({'; '.join(errors)})")
+        return 1
+
+    stage = str(guardrail.get("stage", "")).strip()
+    allow = bool(guardrail.get("allow_consumer_expansion", False))
+    print(f"Rollout guardrails: PASS (stage={stage}, allow_consumer_expansion={str(allow).lower()})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -40,6 +40,9 @@ python3 scripts/validate_smoke_docs.py
 echo "==> gateway parity gate readiness"
 python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json
 
+echo "==> rollout guardrails"
+python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json
+
 echo "==> private IPv4 address gate (docs must use placeholders)"
 python3 - <<'PY'
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add explicit add-on rollout guardrail config (`helianthus/rollout_guardrails.json`)
- add rollout guardrail validator (`scripts/check_rollout_guardrails.py`) enforcing pre-parity block
- integrate guardrail validation in local and PR CI flows
- document guardrail validation commands and architecture note

## Validation
- ./scripts/ci_local.sh

Fixes #88
