### PR TITLE
Integrate MCP-first cruise-control into main

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -58,3 +58,9 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/validate_smoke_docs.py
+
+      - name: Validate gateway parity gate artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -70,3 +70,9 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json
+
+      - name: Run post-parity enablement tasks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/run_post_parity_enablement.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json --addon-config helianthus/config.json --smoke-runbook SMOKE_RUNBOOK.md

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -64,3 +64,9 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json
+
+      - name: Validate rollout guardrails
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,3 +17,4 @@ The container runs a placeholder command that logs a startup message and stays a
 
 Add-on consumer expansion is controlled by `helianthus/rollout_guardrails.json`.
 Default stage is `pre_parity`, which blocks consumer expansion until parity completion gates are approved.
+Post-parity enablement tasks are executed via `scripts/run_post_parity_enablement.py` and only run when guardrails are in `post_parity` stage with green parity artifact gates.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -12,3 +12,8 @@ This repository is a minimal Home Assistant add-on skeleton for Helianthus. Ther
 ## Runtime
 
 The container runs a placeholder command that logs a startup message and stays alive. No ports, services, or integrations are configured at this stage.
+
+## Consumer Rollout Guardrails
+
+Add-on consumer expansion is controlled by `helianthus/rollout_guardrails.json`.
+Default stage is `pre_parity`, which blocks consumer expansion until parity completion gates are approved.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 | terminology gate (CI parity) | `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi` |
 | smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
 | gateway parity gate readiness | `python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
+| rollout guardrails | `python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | smoke checker CLI | `python3 scripts/smoke_addon_checklist.py --help` |
 
 ## Link Map

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 | add-on config syntax | `python3 -m json.tool helianthus/config.json >/dev/null` |
 | terminology gate (CI parity) | `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi` |
 | smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
+| gateway parity gate readiness | `python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | smoke checker CLI | `python3 scripts/smoke_addon_checklist.py --help` |
 
 ## Link Map

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 | smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
 | gateway parity gate readiness | `python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | rollout guardrails | `python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
+| post-parity enablement tasks | `python3 scripts/run_post_parity_enablement.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json --addon-config helianthus/config.json --smoke-runbook SMOKE_RUNBOOK.md` |
 | smoke checker CLI | `python3 scripts/smoke_addon_checklist.py --help` |
 
 ## Link Map

--- a/helianthus/rollout_guardrails.json
+++ b/helianthus/rollout_guardrails.json
@@ -1,0 +1,8 @@
+{
+  "stage": "pre_parity",
+  "allow_consumer_expansion": false,
+  "required_gateway_gates": [
+    "parity_contract",
+    "tool_classification"
+  ]
+}

--- a/scripts/check_gateway_parity_gate.py
+++ b/scripts/check_gateway_parity_gate.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Validate gateway parity artifact readiness markers for add-on rollout gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+REQUIRED_SOURCE_REPO = "d3vi1/helianthus-ebusgateway"
+REQUIRED_GATES = ("parity_contract", "tool_classification")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate gateway parity gate artifact")
+    parser.add_argument("--artifact", required=True, help="Path to parity artifact JSON")
+    parser.add_argument(
+        "--source-repo",
+        default=REQUIRED_SOURCE_REPO,
+        help="Expected gateway source repository",
+    )
+    return parser.parse_args()
+
+
+def load_artifact(path: str) -> dict[str, Any]:
+    artifact_path = Path(path)
+    payload = json.loads(artifact_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("artifact root must be a JSON object")
+    return payload
+
+
+def validate_artifact(payload: dict[str, Any], expected_source_repo: str) -> list[str]:
+    errors: list[str] = []
+
+    source_repo = str(payload.get("source_repo", "")).strip()
+    if source_repo != expected_source_repo:
+        errors.append(
+            f"source_repo mismatch: got={source_repo or '<empty>'} expected={expected_source_repo}"
+        )
+
+    if not str(payload.get("source_ref", "")).strip():
+        errors.append("source_ref missing")
+    if not str(payload.get("generated_at", "")).strip():
+        errors.append("generated_at missing")
+
+    gates = payload.get("gates")
+    if not isinstance(gates, dict):
+        errors.append("gates missing or invalid")
+        return errors
+
+    for gate_name in REQUIRED_GATES:
+        gate = gates.get(gate_name)
+        if not isinstance(gate, dict):
+            errors.append(f"gate {gate_name} missing")
+            continue
+        status = str(gate.get("status", "")).strip().lower()
+        if status != "pass":
+            errors.append(f"gate {gate_name} status is {status or '<empty>'}, expected pass")
+
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        payload = load_artifact(args.artifact)
+    except FileNotFoundError:
+        print(f"Gateway parity gate: FAIL (artifact missing: {args.artifact})")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Gateway parity gate: FAIL (invalid json: {exc})")
+        return 1
+    except ValueError as exc:
+        print(f"Gateway parity gate: FAIL ({exc})")
+        return 1
+
+    errors = validate_artifact(payload, args.source_repo)
+    if errors:
+        print(f"Gateway parity gate: FAIL ({'; '.join(errors)})")
+        return 1
+
+    print("Gateway parity gate: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_rollout_guardrails.py
+++ b/scripts/check_rollout_guardrails.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Validate add-on rollout guardrails against gateway parity artifact status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import check_gateway_parity_gate as parity
+
+VALID_STAGES = {"pre_parity", "post_parity"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate add-on rollout guardrails")
+    parser.add_argument(
+        "--guardrail",
+        default="helianthus/rollout_guardrails.json",
+        help="Path to add-on rollout guardrail config",
+    )
+    parser.add_argument(
+        "--artifact",
+        default="scripts/fixtures/gateway_parity_artifact_pass.json",
+        help="Path to gateway parity artifact JSON",
+    )
+    parser.add_argument(
+        "--source-repo",
+        default=parity.REQUIRED_SOURCE_REPO,
+        help="Expected gateway source repository",
+    )
+    return parser.parse_args()
+
+
+def load_guardrail(path: str) -> dict:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("guardrail config must be a JSON object")
+    return payload
+
+
+def validate_guardrails(guardrail: dict, artifact: dict, source_repo: str) -> list[str]:
+    errors: list[str] = []
+
+    stage = str(guardrail.get("stage", "")).strip()
+    if stage not in VALID_STAGES:
+        errors.append(f"invalid stage: {stage or '<empty>'}")
+        return errors
+
+    allow_consumer_expansion = bool(guardrail.get("allow_consumer_expansion", False))
+
+    required_gates = guardrail.get("required_gateway_gates", list(parity.REQUIRED_GATES))
+    if not isinstance(required_gates, list) or not required_gates:
+        errors.append("required_gateway_gates missing or invalid")
+        return errors
+
+    for gate in required_gates:
+        gate_name = str(gate).strip()
+        if not gate_name:
+            errors.append("required_gateway_gates contains empty value")
+            continue
+        if gate_name not in parity.REQUIRED_GATES:
+            errors.append(f"unsupported required gate: {gate_name}")
+
+    if errors:
+        return errors
+
+    if stage == "pre_parity":
+        if allow_consumer_expansion:
+            errors.append("pre_parity stage forbids allow_consumer_expansion=true")
+        return errors
+
+    if not allow_consumer_expansion:
+        errors.append("post_parity stage requires allow_consumer_expansion=true")
+
+    parity_errors = parity.validate_artifact(artifact, source_repo)
+    if parity_errors:
+        errors.extend(parity_errors)
+        return errors
+
+    gates = artifact.get("gates") if isinstance(artifact.get("gates"), dict) else {}
+    for gate in required_gates:
+        gate_name = str(gate)
+        gate_payload = gates.get(gate_name, {})
+        status = str(gate_payload.get("status", "")).strip().lower()
+        if status != "pass":
+            errors.append(f"required gate {gate_name} is not pass")
+
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        guardrail = load_guardrail(args.guardrail)
+    except FileNotFoundError:
+        print(f"Rollout guardrails: FAIL (guardrail missing: {args.guardrail})")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Rollout guardrails: FAIL (invalid guardrail json: {exc})")
+        return 1
+    except ValueError as exc:
+        print(f"Rollout guardrails: FAIL ({exc})")
+        return 1
+
+    try:
+        artifact = parity.load_artifact(args.artifact)
+    except FileNotFoundError:
+        print(f"Rollout guardrails: FAIL (parity artifact missing: {args.artifact})")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Rollout guardrails: FAIL (invalid parity artifact json: {exc})")
+        return 1
+    except ValueError as exc:
+        print(f"Rollout guardrails: FAIL ({exc})")
+        return 1
+
+    errors = validate_guardrails(guardrail, artifact, args.source_repo)
+    if errors:
+        print(f"Rollout guardrails: FAIL ({'; '.join(errors)})")
+        return 1
+
+    stage = str(guardrail.get("stage", "")).strip()
+    allow = bool(guardrail.get("allow_consumer_expansion", False))
+    print(f"Rollout guardrails: PASS (stage={stage}, allow_consumer_expansion={str(allow).lower()})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -43,6 +43,9 @@ python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway
 echo "==> rollout guardrails"
 python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json
 
+echo "==> post-parity enablement tasks"
+python3 scripts/run_post_parity_enablement.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json --addon-config helianthus/config.json --smoke-runbook SMOKE_RUNBOOK.md
+
 echo "==> private IPv4 address gate (docs must use placeholders)"
 python3 - <<'PY'
 from __future__ import annotations

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -40,6 +40,9 @@ python3 scripts/validate_smoke_docs.py
 echo "==> gateway parity gate readiness"
 python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json
 
+echo "==> rollout guardrails"
+python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json
+
 echo "==> private IPv4 address gate (docs must use placeholders)"
 python3 - <<'PY'
 from __future__ import annotations

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -37,6 +37,9 @@ fi
 echo "==> validate smoke runbook structure"
 python3 scripts/validate_smoke_docs.py
 
+echo "==> gateway parity gate readiness"
+python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json
+
 echo "==> private IPv4 address gate (docs must use placeholders)"
 python3 - <<'PY'
 from __future__ import annotations

--- a/scripts/fixtures/gateway_parity_artifact_pass.json
+++ b/scripts/fixtures/gateway_parity_artifact_pass.json
@@ -1,0 +1,15 @@
+{
+  "source_repo": "d3vi1/helianthus-ebusgateway",
+  "source_ref": "refs/heads/mcpfirst-cruise-control",
+  "generated_at": "2026-02-24T00:00:00Z",
+  "gates": {
+    "parity_contract": {
+      "status": "pass",
+      "details": "mcp parity_contract_test passed"
+    },
+    "tool_classification": {
+      "status": "pass",
+      "details": "mcp tool_classification_test passed"
+    }
+  }
+}

--- a/scripts/run_post_parity_enablement.py
+++ b/scripts/run_post_parity_enablement.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Run add-on post-parity enablement tasks when rollout guardrails allow them."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import check_gateway_parity_gate as parity
+import check_rollout_guardrails as guardrails
+
+REQUIRED_CONFIG_OPTIONS = ("http_port", "graphql_path", "subscription_path", "mcp_path")
+REQUIRED_RUNBOOK_MARKERS = ("CHECK_CONNECTION_GRAPHQL", "CHECK_CONNECTION_MCP")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run add-on post-parity enablement tasks")
+    parser.add_argument(
+        "--guardrail",
+        default="helianthus/rollout_guardrails.json",
+        help="Path to rollout guardrail config",
+    )
+    parser.add_argument(
+        "--artifact",
+        default="scripts/fixtures/gateway_parity_artifact_pass.json",
+        help="Path to gateway parity artifact",
+    )
+    parser.add_argument(
+        "--source-repo",
+        default=parity.REQUIRED_SOURCE_REPO,
+        help="Expected gateway source repository",
+    )
+    parser.add_argument(
+        "--addon-config",
+        default="helianthus/config.json",
+        help="Path to add-on config.json",
+    )
+    parser.add_argument(
+        "--smoke-runbook",
+        default="SMOKE_RUNBOOK.md",
+        help="Path to smoke runbook markdown",
+    )
+    return parser.parse_args()
+
+
+def run_enablement_checks(addon_config_path: str, smoke_runbook_path: str) -> list[str]:
+    errors: list[str] = []
+
+    try:
+        addon_config = json.loads(Path(addon_config_path).read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return [f"add-on config missing: {addon_config_path}"]
+    except json.JSONDecodeError as exc:
+        return [f"add-on config invalid json: {exc}"]
+
+    options = addon_config.get("options") if isinstance(addon_config, dict) else None
+    schema = addon_config.get("schema") if isinstance(addon_config, dict) else None
+    if not isinstance(options, dict):
+        errors.append("add-on config options missing or invalid")
+    if not isinstance(schema, dict):
+        errors.append("add-on config schema missing or invalid")
+
+    for key in REQUIRED_CONFIG_OPTIONS:
+        if isinstance(options, dict) and key not in options:
+            errors.append(f"add-on config options missing key: {key}")
+        if isinstance(schema, dict) and key not in schema:
+            errors.append(f"add-on config schema missing key: {key}")
+
+    try:
+        runbook_text = Path(smoke_runbook_path).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        errors.append(f"smoke runbook missing: {smoke_runbook_path}")
+        return errors
+
+    for marker in REQUIRED_RUNBOOK_MARKERS:
+        if marker not in runbook_text:
+            errors.append(f"smoke runbook missing marker: {marker}")
+
+    return errors
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        guardrail = guardrails.load_guardrail(args.guardrail)
+    except FileNotFoundError:
+        print(f"Post-parity enablement: FAIL (guardrail missing: {args.guardrail})")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Post-parity enablement: FAIL (invalid guardrail json: {exc})")
+        return 1
+    except ValueError as exc:
+        print(f"Post-parity enablement: FAIL ({exc})")
+        return 1
+
+    stage = str(guardrail.get("stage", "")).strip()
+    if stage != "post_parity":
+        print(f"Post-parity enablement: SKIP (stage={stage or '<empty>'})")
+        return 0
+
+    try:
+        artifact = parity.load_artifact(args.artifact)
+    except FileNotFoundError:
+        print(f"Post-parity enablement: FAIL (parity artifact missing: {args.artifact})")
+        return 1
+    except json.JSONDecodeError as exc:
+        print(f"Post-parity enablement: FAIL (invalid parity artifact json: {exc})")
+        return 1
+    except ValueError as exc:
+        print(f"Post-parity enablement: FAIL ({exc})")
+        return 1
+
+    rollout_errors = guardrails.validate_guardrails(guardrail, artifact, args.source_repo)
+    if rollout_errors:
+        print(f"Post-parity enablement: FAIL ({'; '.join(rollout_errors)})")
+        return 1
+
+    enablement_errors = run_enablement_checks(args.addon_config, args.smoke_runbook)
+    if enablement_errors:
+        print(f"Post-parity enablement: FAIL ({'; '.join(enablement_errors)})")
+        return 1
+
+    print("Post-parity enablement: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Final integration of MCP-first cruise-control work into main.\n\nValidation run locally because GitHub CI budget is exhausted:\n- bash scripts/ci_local.sh (PASS)\n\nScope includes parity guardrails and rollout enforcement updates aligned with MCP-first policy.