### PR TITLE
issue-100: bump add-on to 0.3.44 (gateway #192 + #207 fixes)

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.43",
+  "version": "0.3.44",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
## Summary
- Bump version from 0.3.43 to 0.3.44
- Triggers HA Supervisor rebuild with latest gateway binary from `main`
- Includes DHW stale TTL durability fix (#192/ebusgateway#206) and DHW TTL bypass on discovery loss fix (#207/ebusgateway#210)

Closes #100

## Test plan
- [ ] Deploy to HA via `ha_addon_update.sh`
- [ ] Verify gateway starts and serves GraphQL/MCP
- [ ] Confirm DHW state behavior on live bus

🤖 Generated with [Claude Code](https://claude.com/claude-code)