### PR TITLE
issue-102: bump add-on version to 0.3.45

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.44",
+  "version": "0.3.45",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
## Summary
- Bump add-on version from 0.3.44 to 0.3.45
- Includes gateway B5.16 energy targeting fix (gateway PR #228 — target BAI instead of BASV2 for energy reads)

## Local CI
All gates pass (`./scripts/ci_local.sh`).

## Build Plan
GH Actions unavailable. Image will be built locally with `docker buildx` and pushed to GHCR.

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)