### PR TITLE
issue-104: bump add-on version to 0.3.46

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.45",
+  "version": "0.3.46",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
## Summary

- Bump addon version 0.3.45 → 0.3.46
- Includes gateway B5.24 VRC energy reads (gateway PR #232)

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)