### PR TITLE
Bump Go builder to 1.26-alpine

### DIFF
--- a/helianthus/Dockerfile
+++ b/helianthus/Dockerfile
@@ -3,7 +3,7 @@
 ARG BUILD_FROM=ghcr.io/home-assistant/base:3.20
 ARG VRCEXPLORER_VERSION=main
 
-FROM --platform=$TARGETPLATFORM golang:1.22-alpine AS builder
+FROM --platform=$TARGETPLATFORM golang:1.26-alpine AS builder
 ARG TARGETARCH
 ARG TARGETVARIANT
 ARG EBUSGATEWAY_VERSION=main


### PR DESCRIPTION
## Summary
- Bump `golang:1.22-alpine` → `golang:1.26-alpine` in Dockerfile builder stage
- Native arm64 compilation with Go 1.22 produced binaries with eBUS communication failures (all B524 reads timing out)
- Cross-compiled binaries from Go 1.26 (darwin/arm64 → linux/arm64) work correctly

Closes #106

## Test plan
- [x] Cross-compiled image deployed to HA: scan=4/4, LIVE_READY, energy accepted=4/0
- [x] Pushed to GHCR as 0.3.47/0.3.47-aarch64/latest-aarch64

🤖 Generated with [Claude Code](https://claude.com/claude-code)