### PR TITLE
feat: persist stable instance GUID in addon

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 `helianthus-ha-addon` is the Home Assistant add-on packaging layer for Helianthus gateway runtime. It runs `helianthus-gateway` in Supervisor and exposes GraphQL/MCP endpoints to Home Assistant operators.
 
+The add-on also owns the stable Helianthus instance GUID used by the Home Assistant integration. It persists a lowercase UUIDv4 in `/data/instance_guid`, keeps it across normal restarts and updates, and passes it through to the gateway for GraphQL and mDNS discovery.
+
 ## Purpose and Scope
 
 ### What belongs in this repository
@@ -113,6 +115,12 @@ python3 scripts/smoke_addon_checklist.py --log-file /tmp/helianthus-addon.log --
 ```
 
 For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
+
+## Stable Instance GUID Lifecycle
+
+- First start with empty `/data`: generate `/data/instance_guid`.
+- Restart or add-on update with preserved `/data`: reuse the same GUID.
+- Reinstall without restored `/data`: generate a new GUID and present as a new Helianthus instance to Home Assistant.
 
 ## Validation Commands
 

--- a/SMOKE_RUNBOOK.md
+++ b/SMOKE_RUNBOOK.md
@@ -64,6 +64,10 @@ ha addons repo add https://github.com/Project-Helianthus/helianthus-ha-addon
 
 After saving config, restart the add-on.
 
+On first start, the add-on also creates `/data/instance_guid` if it does not already exist.
+Preserving `/data` across updates keeps the same Helianthus identity; reinstalling without `/data`
+creates a new identity that Home Assistant should treat as a new instance.
+
 ## Deterministic smoke checklist
 
 1) Export add-on logs:

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -49,6 +49,13 @@ Source-address persistence:
 - `source_addr_state_file` (default `/data/source_addr.last`) stores the last explicit source address used by the gateway.
 - On restart with `source_addr=auto` (and non-`ebusd-tcp` transport), the add-on reuses the persisted address when present.
 
+Stable instance GUID persistence:
+
+- The add-on stores the Helianthus instance GUID at `/data/instance_guid`.
+- If the file is missing or invalid, startup generates a new lowercase UUIDv4 and persists it atomically.
+- The persisted GUID survives normal restarts and updates as long as `/data` is preserved.
+- Removing `/data/instance_guid` or reinstalling without restoring `/data` creates a new Helianthus instance identity.
+
 For transition mode via `helianthus-ebus-adapter-proxy`, set `proxy_profile=enh|ens` and
 `proxy_endpoint=<host:port>` (or full endpoint URI); startup logs emit proxy profile/endpoint markers.
 

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -25,6 +25,7 @@ write_timeout=$(bashio::config 'write_timeout')
 dial_timeout=$(bashio::config 'dial_timeout')
 adapter_proxy_enabled=$(bashio::config 'adapter_proxy_enabled')
 adapter_proxy_port=$(bashio::config 'adapter_proxy_port')
+instance_guid_file="/data/instance_guid"
 
 source_addr_state_file=$(printf '%s' "${source_addr_state_file}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
 
@@ -47,7 +48,62 @@ normalize_source_addr_value() {
     return 0
   fi
 
-  return 1
+	return 1
+}
+
+normalize_instance_guid() {
+	local raw normalized
+	raw="$1"
+	normalized=$(printf '%s' "${raw}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+	if [ -z "${normalized}" ]; then
+		return 1
+	fi
+	if [[ "${normalized}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]; then
+		printf '%s' "${normalized}"
+		return 0
+	fi
+	return 1
+}
+
+load_instance_guid_state() {
+	if [ ! -f "${instance_guid_file}" ]; then
+		return 1
+	fi
+
+	local stored
+	stored=$(head -n 1 "${instance_guid_file}" 2>/dev/null || true)
+	if [ -z "${stored}" ]; then
+		return 1
+	fi
+
+	normalize_instance_guid "${stored}"
+}
+
+persist_instance_guid_state() {
+	local value tmp dir
+	value="$1"
+	if [ -z "${value}" ]; then
+		return 1
+	fi
+
+	dir=$(dirname "${instance_guid_file}")
+	tmp="${instance_guid_file}.tmp"
+
+	mkdir -p "${dir}" 2>/dev/null || return 1
+	if printf '%s\n' "${value}" >"${tmp}" 2>/dev/null; then
+		mv -f "${tmp}" "${instance_guid_file}" 2>/dev/null || return 1
+	fi
+	rm -f "${tmp}" 2>/dev/null || true
+	return 0
+}
+
+generate_instance_guid() {
+	local generated
+	generated=""
+	if [ -r /proc/sys/kernel/random/uuid ]; then
+		generated=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || true)
+	fi
+	normalize_instance_guid "${generated}"
 }
 
 load_source_addr_state() {
@@ -220,6 +276,27 @@ if [ -n "${persist_source_addr}" ] && [ "${effective_transport}" != "ebusd-tcp" 
   persist_source_addr_state "${persist_source_addr}"
 fi
 
+instance_guid=""
+if [ -f "${instance_guid_file}" ]; then
+  instance_guid=$(load_instance_guid_state || true)
+  if [ -z "${instance_guid}" ]; then
+    bashio::log.warning "Invalid instance GUID in ${instance_guid_file}; regenerating"
+  fi
+fi
+
+if [ -z "${instance_guid}" ]; then
+  instance_guid=$(generate_instance_guid || true)
+  if [ -z "${instance_guid}" ]; then
+    bashio::exit.nok "Failed to generate stable instance GUID"
+  fi
+  if ! persist_instance_guid_state "${instance_guid}"; then
+    bashio::exit.nok "Failed to persist stable instance GUID to ${instance_guid_file}"
+  fi
+  bashio::log.info "Generated stable instance GUID ${instance_guid}"
+else
+  bashio::log.info "Using persisted stable instance GUID ${instance_guid}"
+fi
+
 if bashio::var.true "${adapter_proxy_enabled}" && ! bashio::var.true "${broadcast}"; then
   bashio::log.warning "adapter_proxy_enabled=true with broadcast=false; enabling broadcast listener"
   broadcast=true
@@ -234,6 +311,7 @@ bashio::log.info "GraphQL endpoint: http://${host}:${http_port}${graphql_path}"
 bashio::log.info "Subscriptions endpoint: http://${host}:${http_port}${subscription_path}"
 bashio::log.info "MCP endpoint: http://${host}:${http_port}${mcp_path}"
 bashio::log.info "mDNS: enabled=${mdns} instance=${mdns_instance}"
+bashio::log.info "Stable instance GUID: ${instance_guid}"
 
 gateway_bin="/usr/local/bin/helianthus-gateway"
 if [ -x "/data/helianthus-gateway" ]; then
@@ -253,6 +331,7 @@ exec "${gateway_bin}" \
   -mcp-path "${mcp_path}" \
   -mdns="${mdns}" \
   -mdns-instance "${mdns_instance}" \
+  -instance-guid "${instance_guid}" \
   -broadcast="${broadcast}" \
   -read-timeout "${read_timeout}" \
   -write-timeout "${write_timeout}" \


### PR DESCRIPTION
## What
- bootstrap a stable lowercase UUIDv4 at `/data/instance_guid`
- preserve the GUID across restart/update by owning persistence in the add-on
- pass the GUID into the gateway with `-instance-guid`
- document update vs reinstall semantics in add-on docs

## Why
- makes the add-on the installation-scoped identity owner
- gives HA a durable identity that survives mutable container IP coordinates

## Validation
- `./scripts/ci_local.sh`
- live add-on log: `Using persisted stable instance GUID 3678381d-034e-4f6a-ab72-fce6eaa91245`
- live host file: `/mnt/data/supervisor/addons/data/local_helianthus/instance_guid` contains `3678381d-034e-4f6a-ab72-fce6eaa91245`
- live add-on log: `Using gateway binary override from /data/helianthus-gateway` after restart

Refs #108