### PR TITLE
feat: expose observe-first flags with default-on for soak validation

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.48",
+  "version": "0.3.49",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [
@@ -51,7 +51,11 @@
     "scan_request_timeout": "400ms",
     "read_timeout": "5s",
     "write_timeout": "5s",
-    "dial_timeout": "5s"
+    "dial_timeout": "5s",
+    "observe_first_enabled": true,
+    "passive_state_direct_apply": false,
+    "passive_config_direct_apply": false,
+    "external_write_policy": "record_only"
   },
   "schema": {
     "adapter_proxy_enabled": "bool",
@@ -83,6 +87,10 @@
     "scan_request_timeout": "str",
     "read_timeout": "str",
     "write_timeout": "str",
-    "dial_timeout": "str"
+    "dial_timeout": "str",
+    "observe_first_enabled": "bool",
+    "passive_state_direct_apply": "bool",
+    "passive_config_direct_apply": "bool",
+    "external_write_policy": "list(record_only|invalidate_only|record_and_invalidate)"
   }
 }

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -25,10 +25,24 @@ write_timeout=$(bashio::config 'write_timeout')
 dial_timeout=$(bashio::config 'dial_timeout')
 adapter_proxy_enabled=$(bashio::config 'adapter_proxy_enabled')
 adapter_proxy_port=$(bashio::config 'adapter_proxy_port')
-observe_first_enabled=$(bashio::config 'observe_first_enabled')
-passive_state_direct_apply=$(bashio::config 'passive_state_direct_apply')
-passive_config_direct_apply=$(bashio::config 'passive_config_direct_apply')
-external_write_policy=$(bashio::config 'external_write_policy')
+observe_first_enabled=$(bashio::config 'observe_first_enabled' 2>/dev/null || true)
+passive_state_direct_apply=$(bashio::config 'passive_state_direct_apply' 2>/dev/null || true)
+passive_config_direct_apply=$(bashio::config 'passive_config_direct_apply' 2>/dev/null || true)
+external_write_policy=$(bashio::config 'external_write_policy' 2>/dev/null || true)
+
+# Apply defaults when Supervisor has not yet merged new config schema keys.
+if [ -z "${observe_first_enabled}" ] || [ "${observe_first_enabled}" = "null" ]; then
+  observe_first_enabled=true
+fi
+if [ -z "${passive_state_direct_apply}" ] || [ "${passive_state_direct_apply}" = "null" ]; then
+  passive_state_direct_apply=false
+fi
+if [ -z "${passive_config_direct_apply}" ] || [ "${passive_config_direct_apply}" = "null" ]; then
+  passive_config_direct_apply=false
+fi
+if [ -z "${external_write_policy}" ] || [ "${external_write_policy}" = "null" ]; then
+  external_write_policy="record_only"
+fi
 instance_guid_file="/data/instance_guid"
 
 source_addr_state_file=$(printf '%s' "${source_addr_state_file}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -25,6 +25,10 @@ write_timeout=$(bashio::config 'write_timeout')
 dial_timeout=$(bashio::config 'dial_timeout')
 adapter_proxy_enabled=$(bashio::config 'adapter_proxy_enabled')
 adapter_proxy_port=$(bashio::config 'adapter_proxy_port')
+observe_first_enabled=$(bashio::config 'observe_first_enabled')
+passive_state_direct_apply=$(bashio::config 'passive_state_direct_apply')
+passive_config_direct_apply=$(bashio::config 'passive_config_direct_apply')
+external_write_policy=$(bashio::config 'external_write_policy')
 instance_guid_file="/data/instance_guid"
 
 source_addr_state_file=$(printf '%s' "${source_addr_state_file}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
@@ -312,6 +316,7 @@ bashio::log.info "Subscriptions endpoint: http://${host}:${http_port}${subscript
 bashio::log.info "MCP endpoint: http://${host}:${http_port}${mcp_path}"
 bashio::log.info "mDNS: enabled=${mdns} instance=${mdns_instance}"
 bashio::log.info "Stable instance GUID: ${instance_guid}"
+bashio::log.info "Observe-first: enabled=${observe_first_enabled} state-direct-apply=${passive_state_direct_apply} config-direct-apply=${passive_config_direct_apply} write-policy=${external_write_policy}"
 
 gateway_bin="/usr/local/bin/helianthus-gateway"
 if [ -x "/data/helianthus-gateway" ]; then
@@ -335,4 +340,8 @@ exec "${gateway_bin}" \
   -broadcast="${broadcast}" \
   -read-timeout "${read_timeout}" \
   -write-timeout "${write_timeout}" \
-  -dial-timeout "${dial_timeout}"
+  -dial-timeout "${dial_timeout}" \
+  -observe-first-enabled="${observe_first_enabled}" \
+  -passive-state-direct-apply="${passive_state_direct_apply}" \
+  -passive-config-direct-apply="${passive_config_direct_apply}" \
+  -external-write-policy "${external_write_policy}"


### PR DESCRIPTION
## Summary

- Add four observe-first configuration options to the HA add-on config schema (`observe_first_enabled`, `passive_state_direct_apply`, `passive_config_direct_apply`, `external_write_policy`)
- Default `observe_first_enabled: true` — enables bus observability (passive message capture, periodicity, watch catalog) on passive-supported transports
- Direct-apply flags default to `false` / `record_only` — no semantic state mutation
- Run script passes all four flags to the gateway binary as CLI arguments
- Startup log reports effective observe-first configuration

## Context

The observe-first execution plan (GW-16, gateway#439) closed with a conservative non-promotion decision: the gateway binary default stays `false`. This PR applies the proven proxy-single-client/ens family scope at the add-on packaging layer, which IS the proven P03 deployment family.

Observe-first without direct-apply is pure passive observation — zero bus writes, zero semantic state mutation, bounded memory (1024 messages, 256 periodicity entries). There is no legitimate reason to not have this enabled when `passiveSupported=true`.

This is Phase 1 (soak). After validation, Phase 2 will make observe-first an intrinsic capability of passive-supported transports in the gateway binary itself.

## Test plan

- [ ] Deploy to live HA system
- [ ] Verify `ebus.v1.runtime.status.get` → `observeFirstEnabled: true`
- [ ] Verify `ebus.v1.bus.summary.get` → populated message/periodicity counts
- [ ] Verify `ebus.v1.bus.messages.list` → passive observations present
- [ ] Verify semantic surfaces (`zones.get`, `dhw.get`, `boiler_status.get`) → no regression
- [ ] 24h soak: no crash, no memory growth, no log anomalies
- [ ] Rollback test: set `observe_first_enabled=false` in HA UI, restart, verify disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)