### PR TITLE
fix: enable passive-state-direct-apply=true by default

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.50",
+  "version": "0.3.51",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [
@@ -53,7 +53,7 @@
     "write_timeout": "5s",
     "dial_timeout": "5s",
     "observe_first_enabled": true,
-    "passive_state_direct_apply": false,
+    "passive_state_direct_apply": true,
     "passive_config_direct_apply": false,
     "external_write_policy": "record_only"
   },

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -35,7 +35,7 @@ if [ -z "${observe_first_enabled}" ] || [ "${observe_first_enabled}" = "null" ];
   observe_first_enabled=true
 fi
 if [ -z "${passive_state_direct_apply}" ] || [ "${passive_state_direct_apply}" = "null" ]; then
-  passive_state_direct_apply=false
+  passive_state_direct_apply=true
 fi
 if [ -z "${passive_config_direct_apply}" ] || [ "${passive_config_direct_apply}" = "null" ]; then
   passive_config_direct_apply=false


### PR DESCRIPTION
## Summary
- Set `passive_state_direct_apply: true` in addon default options and run script fallback
- Aligns with gateway PR Project-Helianthus/helianthus-ebusgateway#460

## Test plan
- [ ] Deploy addon → verify gateway starts with `-passive-state-direct-apply=true` in logs
- [ ] Verify `ebus_v1_runtime_status_get` shows `passive_state_direct_apply=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)