### PR TITLE
bump: 0.3.54 - passive ENH observer decode fix

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.53",
+  "version": "0.3.54",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [


### PR DESCRIPTION
Fixes #112.

## Summary
- bump the HA add-on version from `0.3.53` to `0.3.54`
- trigger a fresh `build-addon` publish from the latest `helianthus-ebusgateway` main
- prepare Home Assistant Supervisor to pull and deploy the passive ENH observer decode fix

## Validation
- ./scripts/ci_local.sh
