### PR TITLE
fix: normalize add-on image org for supervisor

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.3.54",
+  "version": "0.3.55",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [
@@ -20,7 +20,7 @@
   "ports_description": {
     "8080/tcp": "GraphQL + MCP HTTP server"
   },
-  "image": "ghcr.io/Project-Helianthus/helianthus-ha-addon",
+  "image": "ghcr.io/project-helianthus/helianthus-ha-addon",
   "options": {
     "adapter_proxy_enabled": false,
     "adapter_proxy_debug": false,


### PR DESCRIPTION
## Summary
- switch the add-on image reference to the lowercase Project-Helianthus GHCR namespace
- bump the add-on version to 0.3.55 so Supervisor sees an update
- unblock HA local-store registration and add-on deployment

## Testing
- ./scripts/ci_local.sh
