### PR TITLE
SAS-02A: migrate source address wrapper authority

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -59,6 +59,12 @@ jobs:
           set -euo pipefail
           python3 scripts/validate_smoke_docs.py
 
+      - name: Validate source address wrapper migration
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_source_addr_wrapper.py
+
       - name: Validate gateway parity gate artifact
         shell: bash
         run: |

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ mcp_path: /mcp
 mdns: true
 ```
 
+`source_addr=auto` delegates source selection to the gateway default policy and does not reuse `/data/source_addr.last`. The legacy `source_addr_state_file` option is kept only so existing installations can retain the old rollback file during migration; the add-on wrapper does not read it as active source authority or rewrite it during startup. Exact `source_addr` values are passed to the gateway as explicit operator intent. With the currently pinned gateway this uses the legacy `-source-addr` compatibility path; newer gateway binaries that advertise startup override validation receive the validate-only startup override flags instead.
+
 ### 4) Adapter-direct configuration with embedded proxy listener
 
 ```yaml
@@ -128,6 +130,7 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 | add-on config syntax | `python3 -m json.tool helianthus/config.json >/dev/null` |
 | terminology gate (CI parity) | `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi` |
 | smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
+| source address wrapper migration | `python3 scripts/check_source_addr_wrapper.py` |
 | gateway parity gate readiness | `python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | rollout guardrails | `python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | post-parity enablement tasks | `python3 scripts/run_post_parity_enablement.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json --addon-config helianthus/config.json --smoke-runbook SMOKE_RUNBOOK.md` |

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -41,11 +41,13 @@ For ebusd TCP mode, use `transport=ebusd-tcp`, `network=tcp`, and set `address=<
 
 For direct UDP-plain adapters, use `transport=udp-plain`, `network=udp`, and set `address=<adapter-host>:<port>`.
 
-Source-address persistence:
+Source address selection:
 
 - `source_addr` defaults to `auto`.
-- `source_addr_state_file` (default `/data/source_addr.last`) stores the last explicit source address used by the gateway.
-- On restart with `source_addr=auto` (and non-`ebusd-tcp` transport), the add-on reuses the persisted address when present.
+- `source_addr=auto` delegates to the gateway default source-selection policy and ignores any legacy `/data/source_addr.last` value.
+- Exact `source_addr` values are passed as explicit gateway intent. The currently pinned gateway receives the legacy `-source-addr` argument; newer gateway binaries that advertise startup override validation receive validate-only startup override arguments.
+- `source_addr_state_file` (default `/data/source_addr.last`) is retained only as a migration/rollback marker for older add-on versions. The wrapper no longer writes this file or promotes it into active source configuration.
+- Rollback to an older add-on may still read the leftover file. To prevent that older behavior, remove `/data/source_addr.last` before rolling back.
 
 Stable instance GUID persistence:
 

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -57,28 +57,6 @@ instance_guid_file="/data/instance_guid"
 
 source_addr_state_file=$(printf '%s' "${source_addr_state_file}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
 
-normalize_source_addr_value() {
-  local raw normalized hex
-  raw="$1"
-  normalized=$(printf '%s' "${raw}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
-  if [ -z "${normalized}" ]; then
-    return 1
-  fi
-
-  if [[ "${normalized}" =~ ^0x[0-9a-f]{1,2}$ ]]; then
-    hex="${normalized#0x}"
-    printf '0x%02x' "$((16#${hex}))"
-    return 0
-  fi
-
-  if [[ "${normalized}" =~ ^[0-9a-f]{1,2}$ ]]; then
-    printf '0x%02x' "$((16#${normalized}))"
-    return 0
-  fi
-
-	return 1
-}
-
 normalize_instance_guid() {
 	local raw normalized
 	raw="$1"
@@ -132,37 +110,6 @@ generate_instance_guid() {
 		generated=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || true)
 	fi
 	normalize_instance_guid "${generated}"
-}
-
-load_source_addr_state() {
-  if [ -z "${source_addr_state_file}" ] || [ ! -f "${source_addr_state_file}" ]; then
-    return 1
-  fi
-
-  local stored
-  stored=$(head -n 1 "${source_addr_state_file}" 2>/dev/null || true)
-  if [ -z "${stored}" ]; then
-    return 1
-  fi
-
-  normalize_source_addr_value "${stored}"
-}
-
-persist_source_addr_state() {
-  local value tmp dir
-  value="$1"
-  if [ -z "${source_addr_state_file}" ] || [ -z "${value}" ]; then
-    return
-  fi
-
-  dir=$(dirname "${source_addr_state_file}")
-  tmp="${source_addr_state_file}.tmp"
-
-  mkdir -p "${dir}" 2>/dev/null || return
-  if printf '%s\n' "${value}" >"${tmp}" 2>/dev/null; then
-    mv -f "${tmp}" "${source_addr_state_file}" 2>/dev/null || true
-  fi
-  rm -f "${tmp}" 2>/dev/null || true
 }
 
 effective_transport="${transport}"
@@ -264,37 +211,6 @@ if [ -z "${scan_request_timeout}" ]; then
   scan_request_timeout="400ms"
 fi
 
-source_addr_normalized=$(printf '%s' "${source_addr}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
-source_addr_args=()
-persisted_source_addr=""
-persist_source_addr=""
-
-if [ "${source_addr_normalized}" = "auto" ] && [ "${effective_transport}" != "ebusd-tcp" ]; then
-  persisted_source_addr=$(load_source_addr_state || true)
-  if [ -n "${persisted_source_addr}" ]; then
-    bashio::log.info "source_addr=auto; reusing persisted source address ${persisted_source_addr}"
-    source_addr="${persisted_source_addr}"
-    source_addr_normalized="${persisted_source_addr}"
-  fi
-fi
-
-if [ "${source_addr_normalized}" = "auto" ]; then
-  if [ "${effective_transport}" = "ebusd-tcp" ]; then
-    bashio::log.info "source_addr=auto with transport=ebusd-tcp; forcing ebusd-compatible source selection"
-    source_addr_args=(-source-addr "auto")
-  else
-    bashio::log.info "source_addr=auto; enabling gentle-join source selection"
-    source_addr_args=(-source-addr "auto")
-  fi
-elif [ -n "${source_addr_normalized}" ]; then
-  source_addr_args=(-source-addr "${source_addr}")
-  persist_source_addr=$(normalize_source_addr_value "${source_addr}" || true)
-fi
-
-if [ -n "${persist_source_addr}" ] && [ "${effective_transport}" != "ebusd-tcp" ]; then
-  persist_source_addr_state "${persist_source_addr}"
-fi
-
 instance_guid=""
 if [ -f "${instance_guid_file}" ]; then
   instance_guid=$(load_instance_guid_state || true)
@@ -340,6 +256,38 @@ gateway_bin="/usr/local/bin/helianthus-gateway"
 if [ -x "/data/helianthus-gateway" ]; then
   gateway_bin="/data/helianthus-gateway"
   bashio::log.info "Using gateway binary override from /data/helianthus-gateway"
+fi
+
+gateway_supports_flag() {
+  local flag output
+  flag="$1"
+  output=$("${gateway_bin}" --help 2>&1 || true)
+  printf '%s\n' "${output}" | grep -Eq -- "(^|[[:space:]])-${flag}([[:space:],=]|$)"
+}
+
+source_addr_normalized=$(printf '%s' "${source_addr}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+source_addr_intent=$(printf '%s' "${source_addr}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+source_addr_args=()
+
+if [ "${source_addr_normalized}" = "auto" ] || [ "${source_addr_normalized}" = "null" ] || [ -z "${source_addr_normalized}" ]; then
+  if [ -n "${source_addr_state_file}" ] && [ -f "${source_addr_state_file}" ]; then
+    bashio::log.info "Legacy source address state file ${source_addr_state_file} is retained for rollback only; source_addr=auto uses gateway default source selection"
+  fi
+  if [ "${effective_transport}" = "ebusd-tcp" ]; then
+    bashio::log.info "source_addr=auto with transport=ebusd-tcp; using gateway default ebusd-compatible source selection"
+  else
+    bashio::log.info "source_addr=auto; using gateway default source-selection policy"
+  fi
+  source_addr_args=(-source-addr "auto")
+elif gateway_supports_flag "startup-source-override" && gateway_supports_flag "startup-source-override-validate"; then
+  bashio::log.info "source_addr=${source_addr_intent}; gateway supports startup source override validation"
+  source_addr_args=(-startup-source-override "${source_addr_intent}" -startup-source-override-validate=true)
+else
+  bashio::log.info "source_addr=${source_addr_intent}; using legacy -source-addr compatibility path without wrapper-side persistence"
+  if [ -n "${source_addr_state_file}" ] && [ -f "${source_addr_state_file}" ]; then
+    bashio::log.info "Legacy source address state file ${source_addr_state_file} is retained for rollback only; explicit source_addr does not rewrite it"
+  fi
+  source_addr_args=(-source-addr "${source_addr_intent}")
 fi
 
 exec "${gateway_bin}" \

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Validate source-address wrapper migration behavior."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_SCRIPT = REPO_ROOT / "helianthus/rootfs/etc/services.d/helianthus-gateway/run"
+TOP_README = REPO_ROOT / "README.md"
+ADDON_README = REPO_ROOT / "helianthus/README.md"
+
+VALID_INSTANCE_GUID = "12345678-1234-4234-9234-123456789abc"
+
+BASHIO_PRELUDE = r'''
+bashio::config() {
+  case "$1" in
+    transport) printf '%s\n' "${TEST_TRANSPORT:-enh}" ;;
+    network) printf '%s\n' "${TEST_NETWORK:-tcp}" ;;
+    address) printf '%s\n' "${TEST_ADDRESS:-203.0.113.10:9999}" ;;
+    proxy_profile) printf '%s\n' "${TEST_PROXY_PROFILE:-disabled}" ;;
+    proxy_endpoint) printf '%s\n' "${TEST_PROXY_ENDPOINT:-}" ;;
+    host) printf '%s\n' "${TEST_HOST:-127.0.0.1}" ;;
+    port) printf '%s\n' "${TEST_PORT:-8080}" ;;
+    path) printf '%s\n' "${TEST_PATH:-/graphql}" ;;
+    http_port) printf '%s\n' "${TEST_HTTP_PORT:-8080}" ;;
+    graphql_path) printf '%s\n' "${TEST_GRAPHQL_PATH:-/graphql}" ;;
+    subscription_path) printf '%s\n' "${TEST_SUBSCRIPTION_PATH:-/graphql/subscriptions}" ;;
+    mcp_path) printf '%s\n' "${TEST_MCP_PATH:-/mcp}" ;;
+    mdns) printf '%s\n' "${TEST_MDNS:-true}" ;;
+    mdns_instance) printf '%s\n' "${TEST_MDNS_INSTANCE:-helianthus}" ;;
+    broadcast) printf '%s\n' "${TEST_BROADCAST:-true}" ;;
+    source_addr) printf '%s\n' "${TEST_SOURCE_ADDR:-auto}" ;;
+    source_addr_state_file) printf '%s\n' "${TEST_SOURCE_ADDR_STATE_FILE}" ;;
+    scan_request_timeout) printf '%s\n' "${TEST_SCAN_REQUEST_TIMEOUT:-400ms}" ;;
+    read_timeout) printf '%s\n' "${TEST_READ_TIMEOUT:-5s}" ;;
+    write_timeout) printf '%s\n' "${TEST_WRITE_TIMEOUT:-5s}" ;;
+    dial_timeout) printf '%s\n' "${TEST_DIAL_TIMEOUT:-5s}" ;;
+    adapter_direct_enabled) printf '%s\n' "${TEST_ADAPTER_DIRECT_ENABLED:-false}" ;;
+    adapter_direct_address) printf '%s\n' "${TEST_ADAPTER_DIRECT_ADDRESS:-}" ;;
+    proxy_listen_addr) printf '%s\n' "${TEST_PROXY_LISTEN_ADDR:-0.0.0.0:19001}" ;;
+    observe_first_enabled) printf '%s\n' "${TEST_OBSERVE_FIRST_ENABLED:-true}" ;;
+    passive_state_direct_apply) printf '%s\n' "${TEST_PASSIVE_STATE_DIRECT_APPLY:-true}" ;;
+    passive_config_direct_apply) printf '%s\n' "${TEST_PASSIVE_CONFIG_DIRECT_APPLY:-false}" ;;
+    external_write_policy) printf '%s\n' "${TEST_EXTERNAL_WRITE_POLICY:-record_only}" ;;
+    *) printf '\n' ;;
+  esac
+}
+
+bashio::var.true() {
+  case "$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" in
+    true|1|yes|on) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+bashio::log.info() {
+  printf 'INFO: %s\n' "$*" >> "${TEST_LOG_FILE}"
+}
+
+bashio::log.warning() {
+  printf 'WARN: %s\n' "$*" >> "${TEST_LOG_FILE}"
+}
+
+bashio::exit.nok() {
+  printf 'NOK: %s\n' "$*" >&2
+  exit 1
+}
+'''
+
+
+def _run(command: list[str], *, cwd: Path = REPO_ROOT) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _write_gateway_stub(path: Path, mode: str) -> None:
+    help_by_mode = {
+        "old": "Usage of gateway:\n  -source-addr string\n",
+        "new": (
+            "Usage of gateway:\n"
+            "  -source-addr string\n"
+            "  -startup-source-override string\n"
+            "  -startup-source-override-validate\n"
+        ),
+    }
+    script = f"""#!/usr/bin/env python3
+from pathlib import Path
+import os
+import sys
+
+mode = {mode!r}
+if "--help" in sys.argv:
+    if mode == "unknown":
+        sys.stderr.write("help unavailable\\n")
+        sys.exit(2)
+    sys.stderr.write({help_by_mode.get(mode, "")!r})
+    sys.exit(0)
+
+Path(os.environ["TEST_ARGV_FILE"]).write_text("\\n".join(sys.argv[1:]) + "\\n", encoding="utf-8")
+sys.exit(0)
+"""
+    _write_executable(path, script)
+
+
+def _write_test_wrapper(path: Path) -> None:
+    text = RUN_SCRIPT.read_text(encoding="utf-8")
+    text = text.replace("/usr/local/bin/helianthus-gateway", "${TEST_GATEWAY_BIN}")
+    text = text.replace("/data/helianthus-gateway", "${TEST_GATEWAY_OVERRIDE_BIN}")
+    text = text.replace("/data/instance_guid", "${TEST_INSTANCE_GUID_FILE}")
+    path.write_text(BASHIO_PRELUDE + "\n" + text, encoding="utf-8")
+
+
+def _run_wrapper_case(
+    *,
+    source_addr: str,
+    gateway_mode: str,
+    existing_state: str | None = None,
+    transport: str = "enh",
+) -> tuple[list[str], str, bool, str]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        state_file = tmp / "source_addr.last"
+        if existing_state is not None:
+            state_file.write_text(existing_state, encoding="utf-8")
+
+        wrapper = tmp / "run-under-test.sh"
+        gateway = tmp / "gateway-stub.py"
+        argv_file = tmp / "argv.txt"
+        log_file = tmp / "wrapper.log"
+        instance_guid_file = tmp / "instance_guid"
+        instance_guid_file.write_text(VALID_INSTANCE_GUID + "\n", encoding="utf-8")
+        _write_test_wrapper(wrapper)
+        _write_gateway_stub(gateway, gateway_mode)
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "TEST_ARGV_FILE": str(argv_file),
+                "TEST_GATEWAY_BIN": str(gateway),
+                "TEST_GATEWAY_OVERRIDE_BIN": str(tmp / "missing-override"),
+                "TEST_INSTANCE_GUID_FILE": str(instance_guid_file),
+                "TEST_LOG_FILE": str(log_file),
+                "TEST_SOURCE_ADDR": source_addr,
+                "TEST_SOURCE_ADDR_STATE_FILE": str(state_file),
+                "TEST_TRANSPORT": transport,
+                "TEST_ADAPTER_DIRECT_ENABLED": "true",
+                "TEST_ADAPTER_DIRECT_ADDRESS": "203.0.113.10:9999",
+            },
+        )
+
+        result = subprocess.run(["bash", str(wrapper)], cwd=REPO_ROOT, env=env, text=True, capture_output=True, check=False)
+        _assert(
+            result.returncode == 0,
+            f"wrapper case source_addr={source_addr!r} gateway_mode={gateway_mode!r} failed\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+
+        argv = argv_file.read_text(encoding="utf-8").splitlines()
+        logs = log_file.read_text(encoding="utf-8") if log_file.exists() else ""
+        state_exists = state_file.exists()
+        state_content = state_file.read_text(encoding="utf-8") if state_exists else ""
+        return argv, logs, state_exists, state_content
+
+
+def _check_static_run_script() -> None:
+    syntax = _run(["bash", "-n", str(RUN_SCRIPT)])
+    _assert(syntax.returncode == 0, f"run script shell syntax failed:\n{syntax.stderr}")
+
+    text = RUN_SCRIPT.read_text(encoding="utf-8")
+    legacy_log_term = "gentle" + "-join"
+    forbidden_terms = [
+        "load_source_addr_state",
+        "persist_source_addr_state",
+        "persist_source_addr=",
+        "persisted_source_addr",
+        legacy_log_term,
+        "reusing persisted source address",
+    ]
+    for term in forbidden_terms:
+        _assert(term not in text, f"run script still contains forbidden source-state term: {term}")
+
+    _assert(
+        'source_addr_args=(-source-addr "auto")' in text,
+        "source_addr=auto must pass the gateway default source-selection intent",
+    )
+    _assert(
+        "startup-source-override" in text and "startup-source-override-validate" in text,
+        "exact source validation flags must be capability-gated in the wrapper",
+    )
+    _assert(
+        "rollback only" in text,
+        "run script must log that leftover source state is rollback-only",
+    )
+
+
+def _check_docs() -> None:
+    forbidden_doc_claims = [
+        "stores the last explicit source address used by the gateway",
+        "reuses the persisted address",
+        "reusing persisted source address",
+    ]
+    for path in (TOP_README, ADDON_README):
+        text = path.read_text(encoding="utf-8")
+        lower = text.lower()
+        for claim in forbidden_doc_claims:
+            _assert(claim not in lower, f"{path.relative_to(REPO_ROOT)} still claims wrapper-side persisted source reuse")
+        _assert("source_addr=auto" in text, f"{path.relative_to(REPO_ROOT)} must document source_addr=auto")
+        _assert("rollback" in lower, f"{path.relative_to(REPO_ROOT)} must document rollback behavior for legacy state")
+
+
+def _check_runtime_cases() -> None:
+    argv, logs, state_exists, state_content = _run_wrapper_case(
+        source_addr="auto",
+        gateway_mode="old",
+        existing_state="0xf7\n",
+    )
+    _assert("-source-addr" in argv, "auto case must pass -source-addr to old gateway")
+    _assert(argv[argv.index("-source-addr") + 1] == "auto", "auto case must not pass legacy state file contents")
+    _assert("0xf7" not in argv, "auto case leaked persisted raw source as active source config")
+    _assert(state_exists and state_content == "0xf7\n", "auto case must not rewrite existing source state file")
+    _assert("gateway default source-selection policy" in logs, "auto case must log gateway default policy")
+    _assert("rollback only" in logs, "auto case must log rollback-only state-file handling")
+
+    argv, _, state_exists, _ = _run_wrapper_case(
+        source_addr="0x71",
+        gateway_mode="old",
+    )
+    _assert("-source-addr" in argv, "old gateway exact source must use legacy -source-addr")
+    _assert(argv[argv.index("-source-addr") + 1] == "0x71", "old gateway exact source changed operator intent")
+    _assert("-startup-source-override" not in argv, "old gateway must not receive new startup override flag")
+    _assert(not state_exists, "old gateway exact source must not create source state file")
+
+    argv, _, state_exists, _ = _run_wrapper_case(
+        source_addr="0x71",
+        gateway_mode="new",
+    )
+    _assert("-startup-source-override" in argv, "new gateway exact source must use startup override")
+    _assert(argv[argv.index("-startup-source-override") + 1] == "0x71", "new gateway exact source changed operator intent")
+    _assert("-startup-source-override-validate=true" in argv, "new gateway exact source must request validate-only startup override")
+    _assert("-source-addr" not in argv, "new gateway exact source must not also use legacy -source-addr")
+    _assert(not state_exists, "new gateway exact source must not create source state file")
+
+    argv, logs, state_exists, _ = _run_wrapper_case(
+        source_addr="0x71",
+        gateway_mode="unknown",
+    )
+    _assert("-source-addr" in argv, "unknown gateway exact source must fall back to legacy -source-addr")
+    _assert("-startup-source-override" not in argv, "unknown gateway must not receive unadvertised startup override flag")
+    _assert("without wrapper-side persistence" in logs, "unknown gateway fallback must not claim validate-only behavior")
+    _assert(not state_exists, "unknown gateway exact source must not create source state file")
+
+
+def main() -> int:
+    try:
+        _check_static_run_script()
+        _check_docs()
+        _check_runtime_cases()
+    except AssertionError as exc:
+        print(f"Source address wrapper check: FAIL ({exc})")
+        return 1
+
+    print("Source address wrapper check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -210,6 +210,8 @@ def _check_static_run_script() -> None:
 
 def _check_docs() -> None:
     forbidden_doc_claims = [
+        "gentle-join",
+        "gentle join",
         "stores the last explicit source address used by the gateway",
         "reuses the persisted address",
         "reusing persisted source address",

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -37,6 +37,9 @@ fi
 echo "==> validate smoke runbook structure"
 python3 scripts/validate_smoke_docs.py
 
+echo "==> source address wrapper migration"
+python3 scripts/check_source_addr_wrapper.py
+
 echo "==> gateway parity gate readiness"
 python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json
 


### PR DESCRIPTION
## Summary

- Stop the add-on wrapper from promoting `source_addr_state_file` contents into active `source_addr=auto` configuration.
- Stop wrapper-side raw source persistence before gateway validation.
- Keep `/data/source_addr.last` as rollback/migration-only state and document that behavior.
- Gate exact-source startup override flags on gateway `--help` capability detection, with legacy `-source-addr` fallback for old or unknown gateway binaries.
- Add CI coverage for auto/state-file isolation, exact-source no-write behavior, docs claims, and old/new/unknown gateway compatibility paths.

Fixes #120.
Refs Project-Helianthus/helianthus-execution-plans#22.

## Validation

- `python3 scripts/check_source_addr_wrapper.py`
- `./scripts/ci_local.sh`