### PR TITLE
feat(addon): P3 — expose enable_static_seed_table flag

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -48,7 +48,8 @@
     "observe_first_enabled": true,
     "passive_state_direct_apply": true,
     "passive_config_direct_apply": false,
-    "external_write_policy": "record_only"
+    "external_write_policy": "record_only",
+    "enable_static_seed_table": false
   },
   "schema": {
     "adapter_direct_enabled": "bool",
@@ -77,6 +78,7 @@
     "observe_first_enabled": "bool",
     "passive_state_direct_apply": "bool",
     "passive_config_direct_apply": "bool",
-    "external_write_policy": "list(record_only|invalidate_only|record_and_invalidate)"
+    "external_write_policy": "list(record_only|invalidate_only|record_and_invalidate)",
+    "enable_static_seed_table": "bool"
   }
 }

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -255,6 +255,17 @@ bashio::log.info "Stable instance GUID: ${instance_guid}"
 bashio::log.info "Observe-first: enabled=${observe_first_enabled} state-direct-apply=${passive_state_direct_apply} config-direct-apply=${passive_config_direct_apply} write-policy=${external_write_policy}"
 bashio::log.info "Static seed table: enabled=${enable_static_seed_table} (productids NETX3 0xF1/0xF6/0x04 + BASV2 0x15/0xEC)"
 
+# Gate `-enable-static-seed-table` on gateway support — the flag is
+# only present in builds containing P3 wiring. Older pinned gateway
+# binaries (or /data/helianthus-gateway overrides) would fail flag
+# parsing at startup. (Codex P1 follow-up on PR #124, 2026-05-08.)
+static_seed_args=()
+if gateway_supports_flag "enable-static-seed-table"; then
+  static_seed_args=(-enable-static-seed-table="${enable_static_seed_table}")
+elif bashio::var.true "${enable_static_seed_table}"; then
+  bashio::log.warning "enable_static_seed_table=true requested but the pinned gateway binary does not support -enable-static-seed-table; flag ignored. Update gateway version (Dockerfile EBUSGATEWAY_VERSION) or override /data/helianthus-gateway with a build that includes the P3 patch."
+fi
+
 gateway_bin="/usr/local/bin/helianthus-gateway"
 if [ -x "/data/helianthus-gateway" ]; then
   gateway_bin="/data/helianthus-gateway"
@@ -319,5 +330,5 @@ exec "${gateway_bin}" \
   -passive-state-direct-apply="${passive_state_direct_apply}" \
   -passive-config-direct-apply="${passive_config_direct_apply}" \
   -external-write-policy "${external_write_policy}" \
-  -enable-static-seed-table="${enable_static_seed_table}" \
+  ${static_seed_args[@]+"${static_seed_args[@]}"} \
   ${proxy_listen_args[@]+"${proxy_listen_args[@]}"}

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -29,6 +29,7 @@ observe_first_enabled=$(bashio::config 'observe_first_enabled' 2>/dev/null || tr
 passive_state_direct_apply=$(bashio::config 'passive_state_direct_apply' 2>/dev/null || true)
 passive_config_direct_apply=$(bashio::config 'passive_config_direct_apply' 2>/dev/null || true)
 external_write_policy=$(bashio::config 'external_write_policy' 2>/dev/null || true)
+enable_static_seed_table=$(bashio::config 'enable_static_seed_table' 2>/dev/null || true)
 
 # Apply defaults when Supervisor has not yet merged new config schema keys.
 if [ -z "${observe_first_enabled}" ] || [ "${observe_first_enabled}" = "null" ]; then
@@ -42,6 +43,9 @@ if [ -z "${passive_config_direct_apply}" ] || [ "${passive_config_direct_apply}"
 fi
 if [ -z "${external_write_policy}" ] || [ "${external_write_policy}" = "null" ]; then
   external_write_policy="record_only"
+fi
+if [ -z "${enable_static_seed_table}" ] || [ "${enable_static_seed_table}" = "null" ]; then
+  enable_static_seed_table=false
 fi
 if [ -z "${adapter_direct_enabled}" ] || [ "${adapter_direct_enabled}" = "null" ]; then
   adapter_direct_enabled=false
@@ -249,6 +253,7 @@ bashio::log.info "MCP endpoint: http://${host}:${http_port}${mcp_path}"
 bashio::log.info "mDNS: enabled=${mdns} instance=${mdns_instance}"
 bashio::log.info "Stable instance GUID: ${instance_guid}"
 bashio::log.info "Observe-first: enabled=${observe_first_enabled} state-direct-apply=${passive_state_direct_apply} config-direct-apply=${passive_config_direct_apply} write-policy=${external_write_policy}"
+bashio::log.info "Static seed table: enabled=${enable_static_seed_table} (productids NETX3 0xF1/0xF6/0x04 + BASV2 0x15/0xEC)"
 
 gateway_bin="/usr/local/bin/helianthus-gateway"
 if [ -x "/data/helianthus-gateway" ]; then
@@ -314,4 +319,5 @@ exec "${gateway_bin}" \
   -passive-state-direct-apply="${passive_state_direct_apply}" \
   -passive-config-direct-apply="${passive_config_direct_apply}" \
   -external-write-policy "${external_write_policy}" \
+  -enable-static-seed-table="${enable_static_seed_table}" \
   ${proxy_listen_args[@]+"${proxy_listen_args[@]}"}

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -255,17 +255,6 @@ bashio::log.info "Stable instance GUID: ${instance_guid}"
 bashio::log.info "Observe-first: enabled=${observe_first_enabled} state-direct-apply=${passive_state_direct_apply} config-direct-apply=${passive_config_direct_apply} write-policy=${external_write_policy}"
 bashio::log.info "Static seed table: enabled=${enable_static_seed_table} (productids NETX3 0xF1/0xF6/0x04 + BASV2 0x15/0xEC)"
 
-# Gate `-enable-static-seed-table` on gateway support — the flag is
-# only present in builds containing P3 wiring. Older pinned gateway
-# binaries (or /data/helianthus-gateway overrides) would fail flag
-# parsing at startup. (Codex P1 follow-up on PR #124, 2026-05-08.)
-static_seed_args=()
-if gateway_supports_flag "enable-static-seed-table"; then
-  static_seed_args=(-enable-static-seed-table="${enable_static_seed_table}")
-elif bashio::var.true "${enable_static_seed_table}"; then
-  bashio::log.warning "enable_static_seed_table=true requested but the pinned gateway binary does not support -enable-static-seed-table; flag ignored. Update gateway version (Dockerfile EBUSGATEWAY_VERSION) or override /data/helianthus-gateway with a build that includes the P3 patch."
-fi
-
 gateway_bin="/usr/local/bin/helianthus-gateway"
 if [ -x "/data/helianthus-gateway" ]; then
   gateway_bin="/data/helianthus-gateway"
@@ -278,6 +267,20 @@ gateway_supports_flag() {
   output=$("${gateway_bin}" --help 2>&1 || true)
   printf '%s\n' "${output}" | grep -Eq -- "(^|[[:space:]])-${flag}([[:space:],=]|$)"
 }
+
+# Gate `-enable-static-seed-table` on gateway support — the flag is
+# only present in builds containing P3 wiring. Older pinned gateway
+# binaries (or /data/helianthus-gateway overrides) would fail flag
+# parsing at startup. (Codex P1+P2 follow-up on PR #124, 2026-05-08:
+# this block must run AFTER gateway_bin selection + gateway_supports_flag
+# definition, otherwise the function call resolves to "command not
+# found" and the conditional is always false.)
+static_seed_args=()
+if gateway_supports_flag "enable-static-seed-table"; then
+  static_seed_args=(-enable-static-seed-table="${enable_static_seed_table}")
+elif bashio::var.true "${enable_static_seed_table}"; then
+  bashio::log.warning "enable_static_seed_table=true requested but the pinned gateway binary does not support -enable-static-seed-table; flag ignored. Update gateway version (Dockerfile EBUSGATEWAY_VERSION) or override /data/helianthus-gateway with a build that includes the P3 patch."
+fi
 
 source_addr_normalized=$(printf '%s' "${source_addr}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
 source_addr_intent=$(printf '%s' "${source_addr}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')


### PR DESCRIPTION
## Summary

Companion to helianthus-ebusgateway P3 (\`feat/p3-wire-static-seed-table\`). Adds \`enable_static_seed_table\` boolean to addon config + s6 service launcher.

Default false to preserve the strict observe-first AD05 contract; operators opt in via the addon configuration UI.

## Changes

- \`helianthus/config.json\`: add option (default false) + schema (bool)
- \`helianthus/rootfs/etc/services.d/helianthus-gateway/run\`:
  - read flag via \`bashio::config\` with null-default fallback to false (matches sibling observe-first pattern)
  - log state at startup via \`bashio::log.info\`
  - pass to gateway binary as \`-enable-static-seed-table=…\`

## LANE classification

**LANE B (schema-additive, default-false)** — no existing operator behavior changes. Compatible with the standard addon update flow; **does NOT require Supervisor force-retag cycle** for the option itself (only the gateway binary update may, separately).

## Test plan

- [x] \`python3 -c "import json; json.load(open(...))"\` — valid JSON
- [x] \`bash -n run\` — shell syntax valid
- [x] bashio idiom matches existing options (observe_first_enabled, passive_*, external_write_policy)
- [ ] Live verify on HA: setting \`enable_static_seed_table: true\` in addon UI → addon restart → log shows "Static seed table: enabled=true" → registry contains 0xF6+0xF1+0x04+0x15+0xEC

## Companion PR

- helianthus-ebusgateway PR (P3 wiring) — must merge first so the gateway binary accepts \`-enable-static-seed-table\`

## References

- Phase C live validation 2026-05-08
- Cruise plan: post-Phase-C P3 of 6-item batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)