### PR TITLE
NETX3 seed log message includes 0xFF (4-face)

### DIFF
--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -253,7 +253,7 @@ bashio::log.info "MCP endpoint: http://${host}:${http_port}${mcp_path}"
 bashio::log.info "mDNS: enabled=${mdns} instance=${mdns_instance}"
 bashio::log.info "Stable instance GUID: ${instance_guid}"
 bashio::log.info "Observe-first: enabled=${observe_first_enabled} state-direct-apply=${passive_state_direct_apply} config-direct-apply=${passive_config_direct_apply} write-policy=${external_write_policy}"
-bashio::log.info "Static seed table: enabled=${enable_static_seed_table} (productids NETX3 0xF1/0xF6/0x04 + BASV2 0x15/0xEC)"
+bashio::log.info "Static seed table: enabled=${enable_static_seed_table} (productids NETX3 0xF1/0xF6/0x04/0xFF + BASV2 0x15/0xEC)"
 
 gateway_bin="/usr/local/bin/helianthus-gateway"
 if [ -x "/data/helianthus-gateway" ]; then


### PR DESCRIPTION
Bumps the startup log message to include 0xFF after [Project-Helianthus/helianthus-ebusreg#142](https://github.com/Project-Helianthus/helianthus-ebusreg/pull/142) added the 4th NETX3 face. Log-text-only; flag handling already exists.