### PR TITLE
feat(runtime-state): M1_TDD_RED — addon wrapper skeleton + RED contract tests

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -65,6 +65,12 @@ jobs:
           set -euo pipefail
           python3 scripts/check_source_addr_wrapper.py
 
+      - name: Validate runtime-state wrapper migration
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_runtime_state_wrapper.py
+
       - name: Validate gateway parity gate artifact
         shell: bash
         run: |

--- a/scripts/check_runtime_state_wrapper.py
+++ b/scripts/check_runtime_state_wrapper.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Helianthus add-on runtime-state wrapper: instance_guid resolution + AD09a guardrail.
+
+Plan: runtime-state-w19-26.locked. ADs implemented here:
+
+- AD09b read precedence: choose meta.instance_guid from /data/runtime_state.json,
+  fall through to legacy /data/instance_guid for halt detection only, generate a
+  fresh UUIDv4 only when both files are absent.
+- AD09a deploy-error guardrail: legacy file present + runtime_state.json absent
+  or invalid -> emit HELIANTHUS_MIGRATION_REQUIRED token, write marker file
+  /data/.helianthus_migration_required with the complete migration template,
+  exit 1 (NOT sysexits-78 per consultant MF-1).
+- AD25 fresh-identity diagnostics: when both files are absent, emit
+  HELIANTHUS_FRESH_IDENTITY warn token and identity_source=generated.
+- AD26 bounded ENOENT retry: tolerate transient absence of runtime_state.json
+  with up to 3 attempts at 100ms apart before falling through to AD09b.
+- AD27 -instance-guid-source flag: emit "runtime_state" / "legacy_migrated" /
+  "generated" / "cli-override" tag based on which read precedence path resolved.
+
+This is the M1_TDD_RED skeleton. Every public function below currently raises
+NotImplementedError. The M6_HA_ADDON_MIGRATION PR replaces these with real
+bodies; the corresponding pytest tests in tests/test_runtime_state_wrapper.py
+turn from RED to GREEN at that point.
+
+CLI surface (used by pr-ci.yml during M1 to avoid CI breakage; the M1 stub
+exits 0 with a skip message):
+
+    python3 scripts/check_runtime_state_wrapper.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+RUNTIME_STATE_FILE = "/data/runtime_state.json"
+LEGACY_INSTANCE_GUID_FILE = "/data/instance_guid"
+MIGRATION_MARKER_FILE = "/data/.helianthus_migration_required"
+
+LOG_TOKEN_MIGRATION_REQUIRED = "HELIANTHUS_MIGRATION_REQUIRED"
+LOG_TOKEN_FRESH_IDENTITY = "HELIANTHUS_FRESH_IDENTITY"
+
+EXIT_OK = 0
+EXIT_MIGRATION_REQUIRED = 1  # AD09a; explicitly NOT sysexits-78 per consultant MF-1.
+
+# AD22 lowercase UUIDv4 regex (must match the JSON Schema artifact in
+# helianthus-docs-ebus runtime-state/runtime_state.schema.json).
+INSTANCE_GUID_REGEX = (
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+# AD27 IdentitySource values, mirrored from
+# helianthus-ebusgateway/internal/runtimestate.IdentitySource.
+IDENTITY_SOURCE_RUNTIME_STATE = "runtime_state"
+IDENTITY_SOURCE_LEGACY_MIGRATED = "legacy_migrated"
+IDENTITY_SOURCE_GENERATED = "generated"
+IDENTITY_SOURCE_CLI_OVERRIDE = "cli-override"
+
+# AD26 retry budget for transient ENOENT on runtime_state.json open.
+RUNTIME_STATE_ENOENT_RETRIES = 3
+RUNTIME_STATE_ENOENT_BACKOFF_MS = 100
+
+# Migration template (AD09a): the complete schema-valid v1 file the operator
+# fills in. written_at uses the epoch sentinel so the operator only has to
+# replace the GUID placeholder; gateway will overwrite written_at on first
+# eager-persist.
+MIGRATION_TEMPLATE = """{
+  "schema_version": 1,
+  "meta": {
+    "instance_guid": "PASTE-LEGACY-GUID-FROM-/data/instance_guid-HERE",
+    "written_at": "1970-01-01T00:00:00Z"
+  }
+}
+"""
+
+
+class ResolveResult:
+    """Outcome of resolve_instance_guid.
+
+    Attributes:
+        guid: chosen instance_guid (lowercase UUIDv4 string), or empty string
+            when AD09a halt was triggered (caller should exit immediately).
+        source: AD27 IdentitySource value.
+        halt: True when AD09a guardrail tripped; caller MUST exit
+            EXIT_MIGRATION_REQUIRED.
+        log_lines: structured log lines to emit (each line has the stable token
+            prefix per AD09a / AD25).
+    """
+
+    def __init__(self, guid: str, source: str, halt: bool, log_lines: list[str]):
+        self.guid = guid
+        self.source = source
+        self.halt = halt
+        self.log_lines = log_lines
+
+
+def resolve_instance_guid(
+    runtime_state_path: str = RUNTIME_STATE_FILE,
+    legacy_path: str = LEGACY_INSTANCE_GUID_FILE,
+) -> ResolveResult:
+    """AD09b read precedence + AD09a halt detection.
+
+    Returns a ResolveResult. When result.halt is True, the caller MUST also
+    write the migration marker file via write_migration_marker() and exit
+    with EXIT_MIGRATION_REQUIRED.
+
+    M1_TDD_RED: raises NotImplementedError. M6_HA_ADDON_MIGRATION provides the
+    real body.
+    """
+    raise NotImplementedError("runtime-state wrapper: M6_HA_ADDON_MIGRATION will provide")
+
+
+def write_migration_marker(
+    marker_path: str = MIGRATION_MARKER_FILE,
+    template: str = MIGRATION_TEMPLATE,
+) -> None:
+    """Write the AD09a migration marker file with the complete template.
+
+    Atomic temp+rename within /data/. Idempotent; overwrites on each call.
+
+    M1_TDD_RED: raises NotImplementedError.
+    """
+    raise NotImplementedError("runtime-state wrapper: M6_HA_ADDON_MIGRATION will provide")
+
+
+def emit_log_lines(lines: list[str], stream=None) -> None:
+    """Write the structured log lines to the Supervisor stdout stream.
+
+    The default stream is sys.stderr (Supervisor captures both stdout and
+    stderr; stderr ensures the banner survives stdout-only filters).
+    """
+    raise NotImplementedError("runtime-state wrapper: M6_HA_ADDON_MIGRATION will provide")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    During M1, this prints a skip message and exits 0 so pr-ci.yml's "Validate
+    runtime-state wrapper migration" step can pass. During M6, this becomes
+    the real entrypoint that the bash run script invokes via `eval`.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+
+    # M1_TDD_RED: skip cleanly so CI passes.
+    print(
+        "check_runtime_state_wrapper: M1_TDD_RED skeleton; M6_HA_ADDON_MIGRATION "
+        "will replace this with the real wrapper. No-op for M1.",
+        file=sys.stderr,
+    )
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_runtime_state_wrapper_red.py
+++ b/tests/test_runtime_state_wrapper_red.py
@@ -1,0 +1,244 @@
+"""M1_TDD_RED tests for the runtime-state wrapper.
+
+These tests reference the contract that M6_HA_ADDON_MIGRATION must satisfy.
+They are RED in M1: every public function in
+scripts/check_runtime_state_wrapper.py raises NotImplementedError, so each
+test fails when run via pytest.
+
+CI does NOT invoke pytest (see .github/workflows/pr-ci.yml — only the
+script's __main__ is invoked, which exits 0 with a skip message during M1).
+The tests are committed as the executable design contract per
+cruise-tdd-gate; M6_HA_ADDON_MIGRATION removes the NotImplementedError
+stubs and these tests turn GREEN.
+
+Run locally with:
+
+    python3 -m pytest tests/test_runtime_state_wrapper_red.py -v
+
+Plan: runtime-state-w19-26.locked. ADs referenced inline per case.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "check_runtime_state_wrapper.py"
+
+
+def _wrapper_module():
+    """Import scripts/check_runtime_state_wrapper.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "check_runtime_state_wrapper", SCRIPT
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+VALID_GUID_A = "8a3f2b9e-4d7c-4f1a-9b5e-2c1f3e7a9d5b"
+VALID_GUID_B = "1234abcd-1234-4abc-9def-987654321abc"
+
+
+def _write_runtime_state(path: Path, *, guid: str | None = VALID_GUID_A,
+                         schema_version: int = 1) -> None:
+    """Write a minimum-valid runtime_state.json fixture."""
+    body: dict = {
+        "schema_version": schema_version,
+        "meta": {
+            "written_at": "2026-05-10T19:42:11Z",
+        },
+    }
+    if guid is not None:
+        body["meta"]["instance_guid"] = guid
+    path.write_text(json.dumps(body, indent=2))
+
+
+# -----------------------------------------------------------------------------
+# AD09b read precedence — 5 cases.
+# -----------------------------------------------------------------------------
+
+
+def test_ad09b_case1_runtime_state_valid_uses_it(tmp_path: Path) -> None:
+    """Case 1: runtime_state valid + meta.instance_guid valid → use it."""
+    module = _wrapper_module()
+    rs_path = tmp_path / "runtime_state.json"
+    legacy_path = tmp_path / "instance_guid"
+    _write_runtime_state(rs_path, guid=VALID_GUID_A)
+
+    result = module.resolve_instance_guid(
+        runtime_state_path=str(rs_path), legacy_path=str(legacy_path)
+    )
+    assert result.guid == VALID_GUID_A
+    assert result.source == module.IDENTITY_SOURCE_RUNTIME_STATE
+    assert result.halt is False
+
+
+def test_ad09b_case2_legacy_only_triggers_ad09a_halt(tmp_path: Path) -> None:
+    """Case 2: legacy present + runtime_state absent → AD09a halt."""
+    module = _wrapper_module()
+    rs_path = tmp_path / "runtime_state.json"  # absent
+    legacy_path = tmp_path / "instance_guid"
+    legacy_path.write_text(VALID_GUID_A + "\n")
+
+    result = module.resolve_instance_guid(
+        runtime_state_path=str(rs_path), legacy_path=str(legacy_path)
+    )
+    assert result.halt is True, "AD09a halt MUST trip when legacy present + runtime_state absent"
+    assert any(
+        module.LOG_TOKEN_MIGRATION_REQUIRED in line for line in result.log_lines
+    ), "AD09a halt must include HELIANTHUS_MIGRATION_REQUIRED log token"
+
+
+def test_ad09b_case3_both_absent_generates_fresh(tmp_path: Path) -> None:
+    """Case 3: both files absent → generate fresh uuid4 + AD25 warn token."""
+    module = _wrapper_module()
+    rs_path = tmp_path / "runtime_state.json"  # absent
+    legacy_path = tmp_path / "instance_guid"  # absent
+
+    result = module.resolve_instance_guid(
+        runtime_state_path=str(rs_path), legacy_path=str(legacy_path)
+    )
+    assert result.halt is False
+    assert result.source == module.IDENTITY_SOURCE_GENERATED
+    assert re.match(module.INSTANCE_GUID_REGEX, result.guid), (
+        f"generated GUID {result.guid!r} must match AD22 regex"
+    )
+    assert any(
+        module.LOG_TOKEN_FRESH_IDENTITY in line for line in result.log_lines
+    ), "AD25 fresh-identity token must be emitted"
+
+
+def test_ad09b_case4_mismatch_runtime_wins(tmp_path: Path) -> None:
+    """Case 4: runtime has GUID-A, legacy has GUID-B → runtime wins, log warning."""
+    module = _wrapper_module()
+    rs_path = tmp_path / "runtime_state.json"
+    legacy_path = tmp_path / "instance_guid"
+    _write_runtime_state(rs_path, guid=VALID_GUID_A)
+    legacy_path.write_text(VALID_GUID_B + "\n")
+
+    result = module.resolve_instance_guid(
+        runtime_state_path=str(rs_path), legacy_path=str(legacy_path)
+    )
+    assert result.halt is False
+    assert result.guid == VALID_GUID_A, (
+        f"AD09b case 4: runtime_state must win on mismatch, got {result.guid!r}"
+    )
+    assert result.source == module.IDENTITY_SOURCE_RUNTIME_STATE
+    # A mismatch warning is expected (operator decision: runtime authority,
+    # legacy is audit artifact).
+    assert any("mismatch" in line.lower() for line in result.log_lines), (
+        "mismatch must produce a warning log line"
+    )
+
+
+def test_ad09b_case5_corrupt_runtime_with_valid_legacy_triggers_halt(
+    tmp_path: Path,
+) -> None:
+    """Case 5: corrupt runtime + valid legacy → AD09a halt (no silent fallback)."""
+    module = _wrapper_module()
+    rs_path = tmp_path / "runtime_state.json"
+    legacy_path = tmp_path / "instance_guid"
+    rs_path.write_text("{not valid json")
+    legacy_path.write_text(VALID_GUID_A + "\n")
+
+    result = module.resolve_instance_guid(
+        runtime_state_path=str(rs_path), legacy_path=str(legacy_path)
+    )
+    assert result.halt is True, (
+        "AD09a halt MUST trip when runtime_state is corrupt + legacy valid (no silent fallback to legacy)"
+    )
+    assert any(
+        module.LOG_TOKEN_MIGRATION_REQUIRED in line for line in result.log_lines
+    )
+
+
+# -----------------------------------------------------------------------------
+# AD09a halt details — marker file content + exit code.
+# -----------------------------------------------------------------------------
+
+
+def test_ad09a_marker_file_contains_complete_template(tmp_path: Path) -> None:
+    """AD09a marker file must contain a schema-valid v1 template."""
+    module = _wrapper_module()
+    marker = tmp_path / "marker"
+    module.write_migration_marker(marker_path=str(marker))
+
+    body = marker.read_text()
+    parsed = json.loads(body)
+    assert parsed["schema_version"] == 1
+    assert "meta" in parsed
+    assert "instance_guid" in parsed["meta"]
+    assert "written_at" in parsed["meta"]
+    # written_at should be the epoch sentinel — operator only fills in the GUID.
+    assert parsed["meta"]["written_at"] == "1970-01-01T00:00:00Z"
+
+
+def test_ad09a_exit_code_is_one_not_seventy_eight() -> None:
+    """AD09a exit code MUST be 1 per consultant MF-1 (not sysexits-78)."""
+    module = _wrapper_module()
+    assert module.EXIT_MIGRATION_REQUIRED == 1, (
+        "AD09a exit code must be 1, never sysexits-78 (collides with Docker conventions)"
+    )
+
+
+# -----------------------------------------------------------------------------
+# AD27 -instance-guid-source flag — sources match precedence path.
+# -----------------------------------------------------------------------------
+
+
+def test_ad27_source_runtime_state(tmp_path: Path) -> None:
+    """Case 1 path → source=runtime_state."""
+    module = _wrapper_module()
+    rs_path = tmp_path / "runtime_state.json"
+    _write_runtime_state(rs_path, guid=VALID_GUID_A)
+    result = module.resolve_instance_guid(
+        runtime_state_path=str(rs_path), legacy_path=str(tmp_path / "absent")
+    )
+    assert result.source == "runtime_state"
+
+
+def test_ad27_source_generated(tmp_path: Path) -> None:
+    """Case 3 path → source=generated."""
+    module = _wrapper_module()
+    result = module.resolve_instance_guid(
+        runtime_state_path=str(tmp_path / "absent_a"),
+        legacy_path=str(tmp_path / "absent_b"),
+    )
+    assert result.source == "generated"
+
+
+# -----------------------------------------------------------------------------
+# AD26 bounded ENOENT retry — transient absence tolerated.
+# -----------------------------------------------------------------------------
+
+
+def test_ad26_enoent_retry_budget(tmp_path: Path) -> None:
+    """ENOENT on runtime_state.json open is retried up to RUNTIME_STATE_ENOENT_RETRIES times."""
+    module = _wrapper_module()
+    assert module.RUNTIME_STATE_ENOENT_RETRIES == 3
+    assert module.RUNTIME_STATE_ENOENT_BACKOFF_MS == 100
+
+
+# -----------------------------------------------------------------------------
+# CLI smoke — main() must accept argv and return an int.
+# -----------------------------------------------------------------------------
+
+
+def test_main_returns_int_zero_during_m1() -> None:
+    """During M1, main() exits 0 with a skip message so CI passes."""
+    module = _wrapper_module()
+    rc = module.main([])
+    assert rc == module.EXIT_OK


### PR DESCRIPTION
## Summary

M1_TDD_RED_ADDON for the [`runtime-state-w19-26.locked`](https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/runtime-state-w19-26.locked) plan. Adds the Python wrapper skeleton + 11 RED contract tests covering AD09a/b/26/27 acceptance for M6_HA_ADDON_MIGRATION.

Closes RTS-ADDON-01 from [90-issue-map.md](https://github.com/Project-Helianthus/helianthus-execution-plans/blob/main/runtime-state-w19-26.locked/90-issue-map.md).

## What's in scope

### `scripts/check_runtime_state_wrapper.py` — wrapper skeleton

- `resolve_instance_guid(runtime_state_path, legacy_path) -> ResolveResult` — AD09b precedence + AD09a halt detection. Raises `NotImplementedError`; M6 fills in.
- `write_migration_marker(marker_path, template) -> None` — atomic temp+rename to `/data/.helianthus_migration_required` with the complete v1 template (epoch sentinel `written_at` so the operator only fills the GUID).
- `emit_log_lines(lines, stream) -> None` — Supervisor stdout/stderr emit.
- `main(argv)` — CLI entry. M1 stub exits 0 with skip message; M6 replaces with real bash-callable entrypoint.
- Constants documented per-AD (file paths, log tokens, exit code, regex, identity-source enum, retry budget, migration template).

### `tests/test_runtime_state_wrapper_red.py` — 11 RED tests

| Test | AD |
|---|---|
| `test_ad09b_case1_runtime_state_valid_uses_it` | AD09b |
| `test_ad09b_case2_legacy_only_triggers_ad09a_halt` | AD09a/AD09b |
| `test_ad09b_case3_both_absent_generates_fresh` | AD09b/AD25 |
| `test_ad09b_case4_mismatch_runtime_wins` | AD09b (operator-locked) |
| `test_ad09b_case5_corrupt_runtime_with_valid_legacy_triggers_halt` | AD09a/AD09b |
| `test_ad09a_marker_file_contains_complete_template` | AD09a |
| `test_ad09a_exit_code_is_one_not_seventy_eight` | consultant MF-1 |
| `test_ad27_source_runtime_state` | AD27 |
| `test_ad27_source_generated` | AD27 |
| `test_ad26_enoent_retry_budget` | AD26 |
| `test_main_returns_int_zero_during_m1` | M1 CI gate |

8 RED-fail (`NotImplementedError`), 3 GREEN (constants + CLI smoke).

### `.github/workflows/pr-ci.yml` — CI wiring

Adds "Validate runtime-state wrapper migration" step calling `python3 scripts/check_runtime_state_wrapper.py`. M1 stub exits 0; M6 replaces with real validation.

## Why no build tag here?

CI runs each Python script directly (no pytest invocation). The CLI stub exits 0 → CI green. Pytest tests fail when run manually → RED gate. No build tag needed; the test file just isn't picked up by CI.

## Test plan

- [x] `python3 scripts/check_runtime_state_wrapper.py` → exit 0, skip message.
- [x] `python3 -m pytest tests/test_runtime_state_wrapper_red.py -v` → 8 RED + 3 GREEN (RED gate active per cruise-tdd-gate).
- [x] `python3 -m pytest tests/ -v` → no regressions to existing tests (3 pre-existing tests still pass).
- [ ] CI green (with new runtime-state wrapper step).

## Plan-side acceptance (per [`12-milestones.md::M1_TDD_RED_ADDON`](https://github.com/Project-Helianthus/helianthus-execution-plans/blob/main/runtime-state-w19-26.locked/12-milestones.md))

- [x] Tests committed and FAILING (RED) on a feature branch.
- [x] CI placeholder step wired so M6 transitions cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)