### PR TITLE
fix(addon): F-1 jq fallback for proxy_listen_addr (HA Supervisor cache bug)

### DIFF
--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -25,6 +25,20 @@ dial_timeout=$(bashio::config 'dial_timeout')
 adapter_direct_enabled=$(bashio::config 'adapter_direct_enabled' 2>/dev/null || true)
 adapter_direct_address=$(bashio::config 'adapter_direct_address' 2>/dev/null || true)
 proxy_listen_addr=$(bashio::config 'proxy_listen_addr' 2>/dev/null || true)
+# F-1 defensive fallback (EBUSD-VERIFICATION-2026-05-10.md): HA Supervisor's
+# /addons/self/options/config endpoint has been observed silently returning
+# empty for proxy_listen_addr despite the value being correctly stored in
+# /data/options.json AND surfaced by /addons/local_helianthus/info. The
+# Supervisor cache-invalidation bug appears specific to this key and reproduces
+# only after the addon options POST without a container recreation. When
+# bashio returns empty, parse the JSON directly via jq as the source of truth.
+if [ -z "${proxy_listen_addr}" ] && [ -f /data/options.json ] && command -v jq >/dev/null 2>&1; then
+  proxy_listen_addr_fallback=$(jq -r '.proxy_listen_addr // empty' /data/options.json 2>/dev/null || true)
+  if [ -n "${proxy_listen_addr_fallback}" ] && [ "${proxy_listen_addr_fallback}" != "null" ]; then
+    bashio::log.warning "bashio::config 'proxy_listen_addr' returned empty; falling back to /data/options.json (value=${proxy_listen_addr_fallback}). Supervisor cache-invalidation bug — see EBUSD-VERIFICATION-2026-05-10.md F-1."
+    proxy_listen_addr="${proxy_listen_addr_fallback}"
+  fi
+fi
 observe_first_enabled=$(bashio::config 'observe_first_enabled' 2>/dev/null || true)
 passive_state_direct_apply=$(bashio::config 'passive_state_direct_apply' 2>/dev/null || true)
 passive_config_direct_apply=$(bashio::config 'passive_config_direct_apply' 2>/dev/null || true)


### PR DESCRIPTION
## Summary

Addresses **F-1** from `_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-10.md`.

HA Supervisor's `/addons/self/options/config` endpoint silently returns empty for `proxy_listen_addr` despite the value being correctly stored in `/data/options.json` AND surfaced by `/addons/local_helianthus/info`. The cache-invalidation bug appears specific to this key (other options propagate normally) and reproduces only after a `POST /addons/<slug>/options` without a container recreation.

## Live-debug evidence (verbatim from the report)

```
POST /addons/local_helianthus/options {proxy_listen_addr:"0.0.0.0:19001"}
  → {"result":"ok"}
/data/options.json (in container).proxy_listen_addr  → "0.0.0.0:19001"  ✅
/addons/self/info.options.proxy_listen_addr          → "0.0.0.0:19001"  ✅
/addons/self/options/config.proxy_listen_addr        → ""              ❌
bashio::config 'proxy_listen_addr'                    → ""              ❌
```

## Fix

When `bashio::config 'proxy_listen_addr'` returns empty AND `/data/options.json` exists AND `jq` is available, parse the JSON file directly. Logs a warning naming the Supervisor bug and the F-1 finding so the workaround is observable in supervisor logs.

Upstream Supervisor bug requires HA core engagement and is out of scope for the gateway team; the addon-side fallback is the operationally necessary workaround.

## Test plan

- [x] `bash -n helianthus/rootfs/etc/services.d/helianthus-gateway/run` clean
- [x] `python3 scripts/check_source_addr_wrapper.py` — passes
- [x] `python3 -m pytest tests/` — 25/25 passes
- [x] No regression on normal-path (when `bashio` returns the value, the fallback is skipped)

## Plan reference

- Source report: `_work_adaptermux_audit/EBUSD-VERIFICATION-2026-05-10.md` F-1
- Unblocks: addon Dockerfile `EBUSGATEWAY_VERSION` bump (carries F-4 + F-6 from helianthus-ebusgateway#617)
- Unblocks: `runtime-state-w19-26.locked` M7_LIVE_VALIDATION operator session

🤖 Generated with [Claude Code](https://claude.com/claude-code)