### PR TITLE
feat(v8): promote v8_classifier_mode default from off → enforce

### DIFF
--- a/helianthus/CHANGELOG.md
+++ b/helianthus/CHANGELOG.md
@@ -1,5 +1,63 @@
 # Changelog
 
+## 0.6.23 (2026-05-21)
+
+### Default `v8_classifier_mode` promoted from `off` → `enforce`
+
+Closes the shadow→enforce promotion gate documented in
+helianthus-docs-ebus/deployment/prometheus-alerts.md. New addon
+installations now default to enforce mode — the v8 classifier
+actively filters mid-telegram wire AUTO-SYN (0xAA) bytes out of
+cross-proxy session byte streams.
+
+**Why this is safe** (live-bus validation evidence):
+
+- `_work_adaptermux_audit/v8-shadow-validation-20260520T055414Z.md`
+  iter-7 captured the per-event distribution behind the aggregate
+  `helianthus_v8_shadow_would_have_dropped_total` counter using the
+  new `GET /debug/v8/admin-events?peek=true` endpoint added in
+  addon 0.6.22.
+- 100% of `aa_injection_drop` events showed the canonical pattern:
+  `byte=0xAA, was_escaped=false, fsm_state=PASSIVE_TRACKING`. Zero
+  false-positives across multiple sustained observation windows.
+- The signal is bounded — ~3 bytes/s under healthy bus, all
+  validated as real wire garbage that enforce mode now filters out
+  of cross-proxy streams.
+
+**In-place upgrade contract:**
+
+- Existing addon installations whose `/data/options.json` explicitly
+  sets `v8_classifier_mode` to `"off"` or `"shadow"` are NOT
+  affected — the addon options blob overrides the config-schema
+  default. Operators opting out of enforce must explicitly set the
+  option in addon options.
+- Operators who never set the option (using the implicit `off`
+  default) get the new `enforce` default automatically on next
+  addon restart.
+
+**Operator opt-out:** for any reason an operator wants the previous
+`off` or `shadow` behavior, set the option explicitly in the addon
+config UI or via `ha addons options local_helianthus --options
+'{"v8_classifier_mode": "off"}'`.
+
+**Observability post-promotion:**
+
+- `helianthus_v8_shadow_would_have_dropped_total` stays at 0 in
+  enforce mode (Classifier.ShadowWouldHaveDroppedTotal returns 0
+  outside ModeShadow).
+- The byte filtering is observable via the inverse counter:
+  `helianthus_v8_classifier_enforce_drops_applied_total` (via
+  `EnforceDropsAppliedTotal()` — already exported by the
+  gateway's classifier; not in PR scope here).
+- `helianthus_round9_absorb_entered_total` should stay at 0 under
+  enforce; any non-zero rate fires
+  `HelianthusRound9FiredUnderProxy` per
+  prometheus-alerts.md.
+
+No config schema changes (option already existed since 0.6.18).
+No gateway pin change (consumes commit `1c76be8` from addon
+0.6.22).
+
 ## 0.6.22 (2026-05-21)
 
 ### v8 admin events HTTP endpoint

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "slug": "helianthus",
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [
@@ -50,7 +50,7 @@
     "passive_config_direct_apply": false,
     "external_write_policy": "record_only",
     "enable_static_seed_table": false,
-    "v8_classifier_mode": "off"
+    "v8_classifier_mode": "enforce"
   },
   "schema": {
     "adapter_direct_enabled": "bool",

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -65,13 +65,26 @@ fi
 if [ -z "${enable_static_seed_table}" ] || [ "${enable_static_seed_table}" = "null" ]; then
   enable_static_seed_table=false
 fi
-# v8 classifier mode default: "off" — production-safe; the rollout
-# (helianthus-ebusgateway v0.6.18) defaults to ModeOff with zero
-# behavior change. Operators opt in by setting this option to "shadow"
-# (canary) or "enforce" (production filtering). See deployment/
-# prometheus-alerts.md in helianthus-docs-ebus for the gate procedure.
+# v8 classifier mode default: "enforce" as of addon 0.6.23
+# (2026-05-21). Per the shadow→enforce promotion gate procedure in
+# helianthus-docs-ebus/deployment/prometheus-alerts.md, the live HA
+# host validation (_work_adaptermux_audit/v8-shadow-validation-*) at
+# iter-7 confirmed 100% true-positive AA-injection signal under
+# shadow mode (every flagged byte was canonical raw-wire 0xAA mid-
+# telegram, with WasEscaped=false — the textbook AA-injection
+# pattern). Zero false-positives observed across multiple sustained
+# observation windows. Enforcing the filter for new installs removes
+# ~3 bytes/s of validated wire garbage from cross-proxy byte streams.
+#
+# In-place upgrade contract: existing addon installations whose
+# /data/options.json explicitly sets `v8_classifier_mode` to "off"
+# or "shadow" are NOT affected by this default change — bashio reads
+# the option value, the fallback only fires when the key is unset.
+# Operators wanting to opt out of enforce mode for their own
+# installation must explicitly set v8_classifier_mode=off or shadow
+# in the addon options before/after upgrade.
 if [ -z "${v8_classifier_mode}" ] || [ "${v8_classifier_mode}" = "null" ]; then
-  v8_classifier_mode="off"
+  v8_classifier_mode="enforce"
 fi
 # Export so the gateway binary's startup wiring (cmd/gateway/main.go
 # os.Getenv(v8classifier.EnvVarName)) reads it. ParseMode validates
@@ -299,7 +312,7 @@ bashio::log.info "mDNS: enabled=${mdns} instance=${mdns_instance}"
 bashio::log.info "Stable instance GUID: ${instance_guid}"
 bashio::log.info "Observe-first: enabled=${observe_first_enabled} state-direct-apply=${passive_state_direct_apply} config-direct-apply=${passive_config_direct_apply} write-policy=${external_write_policy}"
 bashio::log.info "Static seed table: enabled=${enable_static_seed_table} (productids NETX3 0xF1/0xF6/0x04/0xFF + BASV2 0x15/0xEC)"
-bashio::log.info "v8 classifier mode: ${v8_classifier_mode} (HELIANTHUS_V8_CLASSIFIER_MODE — off=zero-overhead default, shadow=canary, enforce=production filtering)"
+bashio::log.info "v8 classifier mode: ${v8_classifier_mode} (HELIANTHUS_V8_CLASSIFIER_MODE — off=zero-overhead, shadow=canary, enforce=production filtering [addon default since 0.6.23])"
 
 gateway_bin="/usr/local/bin/helianthus-gateway"
 if [ -x "/data/helianthus-gateway" ]; then


### PR DESCRIPTION
## Why

Closes the shadow→enforce promotion gate documented in [helianthus-docs-ebus/deployment/prometheus-alerts.md](https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/deployment/prometheus-alerts.md). After iter-7 of the live-bus validation (`_work_adaptermux_audit/v8-shadow-validation-20260520T055414Z.md`), the shadow signal is confirmed clean:

- 100% of `aa_injection_drop` events captured via the new `GET /debug/v8/admin-events?peek=true` endpoint match the canonical AA-injection pattern (`byte=0xAA, was_escaped=false, fsm_state=PASSIVE_TRACKING`).
- Zero false-positives observed across multiple sustained observation windows on the live HA host @ 192.168.100.4.
- Signal rate ~3 bytes/s under healthy bus — all validated as real wire garbage that enforce mode now filters out of cross-proxy session streams.

## What

Three places changed in tandem so fresh-install and in-place-upgrade flows behave identically:

1. **`helianthus/config.json`** — `v8_classifier_mode` schema default: `"off"` → `"enforce"`.
2. **`helianthus/rootfs/etc/services.d/helianthus-gateway/run`** — the bashio-fallback default (when `/data/options.json` lacks the key) flipped to match. Without this, an upgrade path from pre-0.6.18 would diverge from a fresh 0.6.23 install.
3. **`helianthus/CHANGELOG.md`** — 0.6.23 entry documenting the promotion, the in-place upgrade contract, and the operator opt-out procedure.

## In-place upgrade contract

- **Operators with an explicit option set:** `/data/options.json` containing `"v8_classifier_mode": "off"` or `"shadow"` is NOT affected — the addon options blob overrides the schema default.
- **Operators using the implicit default:** automatic flip to `enforce` on next restart.
- **Opt-out:** `ha addons options local_helianthus --options '{"v8_classifier_mode": "off"}'` (before or after upgrade).

The operator's own running addon on the cruise HA host is currently set to `shadow` (per iter-5 deploy), so it is NOT affected by this default change — but on next manual flip to enforce or on a future restart-after-options-reset, the new default applies.

## Out of scope

- Gateway pin change (consumes commit `1c76be8` from addon 0.6.22 — no need to bump).
- New config schema keys (option exists since 0.6.18).
- New env vars / behavior changes for `off` or `shadow` modes — the runtime gateway code is unchanged.

## Test plan

- [x] `python3 scripts/check_source_addr_wrapper.py` passes.
- [x] `git grep -nIwiE 'm[a]ster|s[l]ave'` clean.
- [ ] CI build all 5 arches green.
- [ ] Post-merge on HA host (operator-discretionary): flip the operator's `v8_classifier_mode` from `shadow` to `enforce`, restart, verify `helianthus_v8_shadow_would_have_dropped_total` stays at 0 (correct — counter only ticks in shadow mode) and `helianthus_round9_absorb_entered_total` stays at 0 (the `HelianthusRound9FiredUnderProxy` invariant).
- [ ] Observe 24h that cross-proxy session traffic stays clean — no operator reports of dropped legitimate bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)