### PR TITLE
Drop deprecated add-on architectures

### DIFF
--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -5,10 +5,7 @@
   "description": "Helianthus eBUS gateway (GraphQL + MCP)",
   "arch": [
     "aarch64",
-    "amd64",
-    "armhf",
-    "armv7",
-    "i386"
+    "amd64"
   ],
   "startup": "services",
   "boot": "auto",


### PR DESCRIPTION
## What
Removes deprecated 32-bit Home Assistant Supervisor architecture entries from the Helianthus add-on manifest.

## Why
Supervisor now warns when add-on manifests advertise deprecated architectures. The add-on remains available for the currently supported 64-bit targets.

## Acceptance Criteria
- [x] Deprecated arch values removed from helianthus/config.json
- [x] Supported arch values preserved: aarch64, amd64
- [x] Local validation passes

Closes #161

Validation:
- ./scripts/ci_local.sh