### PR TITLE
Persist gateway semantic cache under add-on data

### DIFF
--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -341,6 +341,14 @@ elif bashio::var.true "${enable_static_seed_table}"; then
   bashio::log.warning "enable_static_seed_table=true requested but the pinned gateway binary does not support -enable-static-seed-table; flag ignored. Update gateway version (Dockerfile EBUSGATEWAY_VERSION) or override /data/helianthus-gateway with a build that includes the P3 patch."
 fi
 
+semantic_cache_args=()
+if gateway_supports_flag "semantic-cache-path"; then
+  semantic_cache_args=(-semantic-cache-path "/data/semantic_cache.json")
+  bashio::log.info "Semantic cache path: /data/semantic_cache.json"
+else
+  bashio::log.warning "Pinned gateway binary does not support -semantic-cache-path; semantic startup cache will remain container-local. Update gateway version (Dockerfile EBUSGATEWAY_VERSION) or override /data/helianthus-gateway with a build that supports semantic cache persistence."
+fi
+
 # Gate `-instance-guid-source` (AD27) on gateway support. The pinned gateway
 # version in Dockerfile/build.yml emits this flag as part of M2_GATEWAY_LOADER,
 # but a `/data/helianthus-gateway` override predating M2 would reject it during
@@ -407,4 +415,5 @@ exec "${gateway_bin}" \
   -passive-config-direct-apply="${passive_config_direct_apply}" \
   -external-write-policy "${external_write_policy}" \
   ${static_seed_args[@]+"${static_seed_args[@]}"} \
+  ${semantic_cache_args[@]+"${semantic_cache_args[@]}"} \
   ${proxy_listen_args[@]+"${proxy_listen_args[@]}"}

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -113,6 +113,7 @@ def _write_gateway_stub(path: Path, mode: str) -> None:
             "  -startup-source-override string\n"
             "  -startup-source-override-validate\n"
             "  -instance-guid-source string\n"
+            "  -semantic-cache-path string\n"
         ),
     }
     script = f"""#!/usr/bin/env python3
@@ -283,6 +284,10 @@ def _check_static_run_script() -> None:
         "rollback only" in text,
         "run script must log that leftover source state is rollback-only",
     )
+    _assert(
+        'semantic_cache_args=(-semantic-cache-path "/data/semantic_cache.json")' in text,
+        "run script must persist semantic startup cache under /data/",
+    )
 
 
 def _check_docs() -> None:
@@ -316,10 +321,15 @@ def _check_runtime_cases() -> None:
     )
     _assert("-source-addr" in argv, "auto case must pass -source-addr to old gateway")
     _assert(argv[argv.index("-source-addr") + 1] == "auto", "auto case must not pass legacy state file contents")
+    _assert("-semantic-cache-path" not in argv, "old gateway must not receive unsupported semantic cache flag")
     _assert("0xf7" not in argv, "auto case leaked persisted raw source as active source config")
     _assert(state_exists and state_content == "0xf7\n", "auto case must not rewrite existing source state file")
     _assert("gateway default source-selection policy" in logs, "auto case must log gateway default policy")
     _assert("rollback only" in logs, "auto case must log rollback-only state-file handling")
+    _assert(
+        "does not support -semantic-cache-path" in logs,
+        "old gateway path must log the semantic-cache compatibility warning",
+    )
     _assert(
         "-instance-guid-source" not in argv,
         "old gateway lacking AD27 flag must not receive -instance-guid-source (compatibility gate)",
@@ -347,6 +357,10 @@ def _check_runtime_cases() -> None:
     _assert(
         argv[argv.index("-instance-guid-source") + 1] == "runtime_state",
         "new gateway must receive the resolver-emitted identity-source tag",
+    )
+    _assert(
+        "-semantic-cache-path" in argv and argv[argv.index("-semantic-cache-path") + 1] == "/data/semantic_cache.json",
+        "new gateway must persist semantic startup cache under /data/",
     )
 
     argv, logs, state_exists, state_content, _ = _run_wrapper_case(

--- a/tests/test_source_addr_wrapper_m4.py
+++ b/tests/test_source_addr_wrapper_m4.py
@@ -27,11 +27,13 @@ def test_source_addr_auto_does_not_reuse_raw_state_file() -> None:
 
     assert "-source-addr" in argv
     assert argv[argv.index("-source-addr") + 1] == "auto"
+    assert "-semantic-cache-path" not in argv
     assert "0xf7" not in argv
     assert state_exists
     assert state_content == "0xf7\n"
     assert "gateway default source-selection policy" in logs
     assert "rollback only" in logs
+    assert "does not support -semantic-cache-path" in logs
 
 
 def test_source_addr_exact_maps_to_explicit_validate_only() -> None:
@@ -45,6 +47,8 @@ def test_source_addr_exact_maps_to_explicit_validate_only() -> None:
     assert "-startup-source-override" in argv
     assert argv[argv.index("-startup-source-override") + 1] == "0x71"
     assert "-startup-source-override-validate=true" in argv
+    assert "-semantic-cache-path" in argv
+    assert argv[argv.index("-semantic-cache-path") + 1] == "/data/semantic_cache.json"
     assert "-source-addr" not in argv
     assert state_exists
     assert "rollback only" in logs


### PR DESCRIPTION
## Summary
- pass -semantic-cache-path /data/semantic_cache.json when the selected gateway binary supports it
- log a compatibility warning instead of breaking older gateway overrides
- extend wrapper checks so the persisted cache argument is covered

## Validation
- python3 scripts/check_source_addr_wrapper.py
- python3 -m pytest tests/test_source_addr_wrapper_m4.py
- ./scripts/ci_local.sh

Closes #163