### PR TITLE
MSP-03C: Add eeBUS HA network proof gate

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -59,6 +59,13 @@ jobs:
           set -euo pipefail
           python3 scripts/validate_smoke_docs.py
 
+      - name: Validate eeBUS HA network proof contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_eebus_ha_network_proof.py --self-test
+          python3 scripts/check_eebus_ha_network_proof.py --artifact scripts/fixtures/eebus_ha_network_proof_contract_pass.json --mode contract
+
       - name: Validate source address wrapper migration
         shell: bash
         run: |
@@ -115,3 +122,10 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/run_post_parity_enablement.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json --addon-config helianthus/config.json --smoke-runbook SMOKE_RUNBOOK.md
+
+      - name: Enforce Markdown private IPv4 placeholders
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/check_markdown_private_ips.py --self-test
+          python3 scripts/check_markdown_private_ips.py

--- a/EEBUS_HA_NETWORK_PROOF.md
+++ b/EEBUS_HA_NETWORK_PROOF.md
@@ -1,0 +1,77 @@
+# eeBUS HA Network Proof
+
+This runbook defines the `MSP-03C` proof artifact for Home Assistant add-on
+networking readiness. It proves the add-on runtime can support a future raw
+eeBUS sidecar, but it does not enable eeBUS, pair devices, persist production
+trust, or expose GraphQL/Portal/Home Assistant consumer semantics.
+
+## Scope
+
+The proof maps to `eebus-transport-gate-v0` cases:
+
+| Case | Scope |
+| --- | --- |
+| `EEBUS-G05` | Listener binds only the configured interface or subnet. Wildcard and unexpected bridge exposure fail. |
+| `EEBUS-G06` | An external LAN peer can browse and resolve the SHIP mDNS service `_ship._tcp`. |
+| `EEBUS-G07` | Disabled mDNS, unavailable Avahi/DBus, and closed pairing are explicit negative states. |
+| `EEBUS-G08` | Manual endpoint fallback reaches the peer when discovery is unavailable. |
+| `EEBUS-G09` | Disposable proof credentials survive restart without writing production trust. |
+
+The CI fixture is a contract fixture, not lab evidence:
+
+```bash
+python3 scripts/check_eebus_ha_network_proof.py \
+  --artifact scripts/fixtures/eebus_ha_network_proof_contract_pass.json \
+  --mode contract
+```
+
+Use `--mode lab` for a real artifact collected from a Home Assistant runtime.
+Lab mode requires `"mode": "lab_run"` and a `lab` object with repo branch,
+commit, add-on build id, command-log ref, interface or subnet ref, external LAN
+peer ref, listener socket ref, mDNS browse/resolve refs, restart ref, and
+evidence IDs for each required case.
+
+## Artifact Rules
+
+The artifact must be public-safe. It must not contain:
+
+- PEM blocks or private keys;
+- passwords, tokens, or secret-bearing values;
+- private or link-local IP addresses;
+- MAC addresses;
+- device serials or full fingerprints;
+- vendor-restricted protocol details.
+
+Use stable redacted references such as `sha256:0123456789ab` for disposable
+identity continuity checks. Public PRs and issues cite only the redacted
+artifact and publishable evidence IDs.
+
+## Lab Collection Checklist
+
+1. Confirm the add-on reports `host_network: true` and `host_dbus: false` from
+   Supervisor metadata.
+2. Start the proof runtime with a disposable store at `/data/eebus-proof`.
+3. Confirm the listener is bound to the configured interface or subnet.
+4. From a second LAN host, confirm TCP reachability to the configured listener.
+5. From that same LAN host, browse and resolve the expected mDNS service.
+6. Disable discovery or close the pairing window and confirm the service is
+   absent or expires after TTL.
+7. Configure a manual endpoint and confirm peer reachability with discovery
+   unavailable.
+8. Restart the proof runtime and confirm the same redacted disposable identity
+   ref, with directory mode `0700` and file mode `0600`.
+9. Run the validator in lab mode:
+
+```bash
+python3 scripts/check_eebus_ha_network_proof.py \
+  --artifact /path/to/redacted-msp-03c-lab-artifact.json \
+  --mode lab
+```
+
+## Non-Goals
+
+- No `eebus.enabled` add-on option is added in this milestone.
+- No SHIP/SPINE listener is started by the production add-on wrapper.
+- No trust or pairing mutation is exposed to web UI, ingress, GraphQL, MCP, or
+  Home Assistant.
+- Same-container or same-bridge success is not accepted as LAN-side proof.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The add-on also owns the stable Helianthus instance GUID used by the Home Assist
 - Add-on runtime startup wiring (`helianthus/rootfs/run.sh`).
 - Add-on image build definition (`helianthus/Dockerfile`).
 - Add-on smoke docs/check tooling (`SMOKE_RUNBOOK.md`, `scripts/smoke_addon_checklist.py`).
+- eeBUS HA runtime network proof tooling for raw-first feasibility
+  (`EEBUS_HA_NETWORK_PROOF.md`, `scripts/check_eebus_ha_network_proof.py`).
 
 ### What does not belong in this repository
 
@@ -129,10 +131,12 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 | add-on config syntax | `python3 -m json.tool helianthus/config.json >/dev/null` |
 | terminology gate (CI parity) | `if git grep -nIwiE 'm[a]ster|s[l]ave'; then echo "Found legacy terminology."; exit 1; fi` |
 | smoke docs gate (CI parity) | `python3 scripts/validate_smoke_docs.py` |
+| eeBUS HA network proof contract | `python3 scripts/check_eebus_ha_network_proof.py --self-test && python3 scripts/check_eebus_ha_network_proof.py --artifact scripts/fixtures/eebus_ha_network_proof_contract_pass.json --mode contract` |
 | source address wrapper migration | `python3 scripts/check_source_addr_wrapper.py` |
 | gateway parity gate readiness | `python3 scripts/check_gateway_parity_gate.py --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | rollout guardrails | `python3 scripts/check_rollout_guardrails.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json` |
 | post-parity enablement tasks | `python3 scripts/run_post_parity_enablement.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json --addon-config helianthus/config.json --smoke-runbook SMOKE_RUNBOOK.md` |
+| Markdown private IPv4 gate | `python3 scripts/check_markdown_private_ips.py --self-test && python3 scripts/check_markdown_private_ips.py` |
 | smoke checker CLI | `python3 scripts/smoke_addon_checklist.py --help` |
 
 ## Link Map
@@ -141,6 +145,7 @@ For full operator sequence and checklist interpretation, use `SMOKE_RUNBOOK.md`.
 
 - Add-on folder docs: `helianthus/README.md`
 - Operator smoke runbook: `SMOKE_RUNBOOK.md`
+- eeBUS HA runtime networking proof: `EEBUS_HA_NETWORK_PROOF.md`
 - Architecture baseline: `ARCHITECTURE.md`
 - Repository conventions: `CONVENTIONS.md`
 - Agent workflow notes: `AGENT.md`

--- a/SMOKE_RUNBOOK.md
+++ b/SMOKE_RUNBOOK.md
@@ -8,7 +8,7 @@ the embedded gateway adaptermux proxy topology, and produces deterministic pass/
 - Home Assistant Supervisor runs the `helianthus` add-on.
 - Add-on transport points to local/lan ebusd TCP endpoint.
 - Example topology values used below:
-  - ebusd endpoint: `192.168.100.2:9999`
+  - ebusd endpoint: `203.0.113.10:9999`
   - proxy profile: `disabled`
   - proxy endpoint: `(none)`
   - add-on HTTP API: `127.0.0.1:8080`
@@ -22,9 +22,9 @@ the embedded gateway adaptermux proxy topology, and produces deterministic pass/
 - Use `proxy_listen_addr` to expose the gateway-embedded adaptermux proxy for other clients.
 - Keep `proxy_profile=disabled`; the add-on no longer starts or wires a standalone adapter-proxy.
 - Example values:
-  - adapter direct address: `enh://192.168.100.2:9999`
+  - adapter direct address: `enh://203.0.113.10:9999`
   - proxy listener: `0.0.0.0:19001`
-  - effective transport marker: `Transport: adapter-direct (tcp adapter-direct://192.168.100.2:9999)`
+  - effective transport marker: `Transport: adapter-direct (tcp adapter-direct://203.0.113.10:9999)`
 
 ## Install and start add-on
 
@@ -45,7 +45,7 @@ ha addons repo add https://github.com/Project-Helianthus/helianthus-ha-addon
 {
   "transport": "ebusd-tcp",
   "network": "tcp",
-  "address": "192.168.100.2:9999",
+  "address": "203.0.113.10:9999",
   "proxy_profile": "disabled",
   "proxy_endpoint": "",
   "host": "127.0.0.1",
@@ -84,7 +84,7 @@ python3 scripts/smoke_addon_checklist.py \
   --log-file /tmp/helianthus-addon.log \
   --transport ebusd-tcp \
   --network tcp \
-  --address 192.168.100.2:9999 \
+  --address 203.0.113.10:9999 \
   --proxy-profile disabled \
   --host 127.0.0.1 \
   --http-port 8080 \
@@ -100,7 +100,7 @@ python3 scripts/smoke_addon_checklist.py \
   --log-file /tmp/helianthus-addon.log \
   --transport ebusd-tcp \
   --network tcp \
-  --address 192.168.100.2:9999 \
+  --address 203.0.113.10:9999 \
   --proxy-profile disabled \
   --host 127.0.0.1 \
   --http-port 8080 \
@@ -117,7 +117,7 @@ python3 scripts/smoke_addon_checklist.py \
   --log-file /tmp/helianthus-addon.log \
   --transport adapter-direct \
   --network tcp \
-  --address adapter-direct://192.168.100.2:9999 \
+  --address adapter-direct://203.0.113.10:9999 \
   --proxy-profile disabled \
   --host 127.0.0.1 \
   --http-port 8080 \

--- a/scripts/check_eebus_ha_network_proof.py
+++ b/scripts/check_eebus_ha_network_proof.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+"""Validate MSP-03C eeBUS HA runtime networking proof artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import ipaddress
+import json
+from pathlib import Path
+import re
+import sys
+import tempfile
+from typing import Any
+
+CONTRACT = "helianthus.eebus.ha-network-proof.v0"
+ISSUE = "MSP-03C"
+REPO = "Project-Helianthus/helianthus-ha-addon"
+REQUIRED_CASES = ("EEBUS-G05", "EEBUS-G06", "EEBUS-G07", "EEBUS-G08", "EEBUS-G09")
+EXPECTED_SHIP_SERVICE_TYPE = "_ship._tcp"
+REDACTED_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{12}$")
+GIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+MAC_RE = re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")
+PEM_RE = re.compile(r"-----BEGIN [A-Z ]+-----|PRIVATE KEY", re.IGNORECASE)
+SERIAL_RE = re.compile(r"\b(?:[0-9]{2}-){3,}[0-9A-Za-z-]{4,}\b")
+SECRET_PATH_RE = re.compile(
+    r"(^|[._\[\]-])(password|passwd|secret|token|api_token|private_key|client_secret|authorization|bearer)([._\[\]-]|$)",
+    re.IGNORECASE,
+)
+SECRET_VALUE_RE = re.compile(
+    r"(password|secret|token=|bearer\s+[a-z0-9._-]+|gh[pousr]_[a-z0-9_]+|eyj[a-z0-9_-]+\.[a-z0-9_-]+\.[a-z0-9_-]+)",
+    re.IGNORECASE,
+)
+CONTRADICTION_KEY_RE = re.compile(
+    r"(wildcard|bridge|ingress|web_ui|admin|production_trust|host_network|host_dbus|same_container|same_host|actual_bind|network_mode)",
+    re.IGNORECASE,
+)
+LAB_EVIDENCE_RE = re.compile(r"^(msp03c-[a-z0-9][a-z0-9-]{5,80}|sha256:[0-9a-f]{12})$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate a redacted MSP-03C eebus-transport-gate-v0 artifact",
+    )
+    parser.add_argument(
+        "--artifact",
+        default="scripts/fixtures/eebus_ha_network_proof_contract_pass.json",
+        help="Path to the proof artifact JSON",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=("contract", "lab"),
+        default="contract",
+        help="contract validates the public fixture shape; lab also requires lab_run mode",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="Run validator regression tests against known-bad mutations",
+    )
+    return parser.parse_args()
+
+
+def load_artifact(path: str) -> dict[str, Any]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("artifact root must be a JSON object")
+    return payload
+
+
+def validate_artifact(payload: dict[str, Any], *, mode: str) -> list[str]:
+    errors: list[str] = []
+
+    errors.extend(_validate_redaction(payload))
+
+    if payload.get("contract") != CONTRACT:
+        errors.append(f"contract mismatch: got={payload.get('contract')!r} expected={CONTRACT}")
+    if payload.get("issue") != ISSUE:
+        errors.append(f"issue mismatch: got={payload.get('issue')!r} expected={ISSUE}")
+    if payload.get("repo") != REPO:
+        errors.append(f"repo mismatch: got={payload.get('repo')!r} expected={REPO}")
+    if not _non_empty_string(payload.get("generated_at")):
+        errors.append("generated_at missing")
+    if payload.get("result") != "PASS":
+        errors.append(f"result must be PASS, got={payload.get('result')!r}")
+
+    errors.extend(_validate_unknown_fields(payload))
+
+    artifact_mode = payload.get("mode")
+    if mode == "lab":
+        if artifact_mode != "lab_run":
+            errors.append(f"lab validation requires mode=lab_run, got={artifact_mode!r}")
+        errors.extend(_validate_lab_run(payload))
+    elif artifact_mode not in {"contract_fixture", "lab_run"}:
+        errors.append(f"invalid mode: {artifact_mode!r}")
+
+    required_cases = payload.get("required_cases")
+    if required_cases != list(REQUIRED_CASES):
+        errors.append(f"required_cases mismatch: got={required_cases!r}")
+
+    topology = _dict(payload.get("topology"))
+    errors.extend(_validate_topology(topology))
+
+    security = _dict(payload.get("security"))
+    errors.extend(_validate_security(security))
+
+    credential_store = _dict(payload.get("credential_store"))
+    errors.extend(_validate_credential_store(credential_store))
+
+    cases = payload.get("cases")
+    if not isinstance(cases, list):
+        errors.append("cases must be a list")
+        return errors
+
+    by_id: dict[str, dict[str, Any]] = {}
+    for idx, case in enumerate(cases):
+        if not isinstance(case, dict):
+            errors.append(f"cases[{idx}] must be an object")
+            continue
+        case_id = case.get("id")
+        if not isinstance(case_id, str):
+            errors.append(f"cases[{idx}].id missing")
+            continue
+        if case_id in by_id:
+            errors.append(f"duplicate case id: {case_id}")
+            continue
+        by_id[case_id] = case
+
+    actual_ids = tuple(by_id.keys())
+    if actual_ids != REQUIRED_CASES:
+        errors.append(f"case order mismatch: got={actual_ids!r} expected={REQUIRED_CASES!r}")
+
+    for case_id in REQUIRED_CASES:
+        case = by_id.get(case_id)
+        if case is None:
+            errors.append(f"missing case: {case_id}")
+            continue
+        if case.get("status") != "PASS":
+            errors.append(f"{case_id}: status must be PASS")
+        evidence = case.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            errors.append(f"{case_id}: evidence must be a non-empty list")
+        elif not all(_non_empty_string(item) for item in evidence):
+            errors.append(f"{case_id}: evidence entries must be non-empty strings")
+
+    if "EEBUS-G05" in by_id:
+        errors.extend(_validate_g05(by_id["EEBUS-G05"]))
+    if "EEBUS-G06" in by_id:
+        errors.extend(_validate_g06(by_id["EEBUS-G06"]))
+    if "EEBUS-G07" in by_id:
+        errors.extend(_validate_g07(by_id["EEBUS-G07"]))
+    if "EEBUS-G08" in by_id:
+        errors.extend(_validate_g08(by_id["EEBUS-G08"]))
+    if "EEBUS-G09" in by_id:
+        errors.extend(_validate_g09(by_id["EEBUS-G09"], credential_store))
+
+    return errors
+
+
+def _validate_topology(topology: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    addon = _dict(topology.get("ha_addon"))
+    lan_peer = _dict(topology.get("lan_peer"))
+
+    if addon.get("host_network") is not True:
+        errors.append("topology.ha_addon.host_network must be true for LAN-side proof")
+    if addon.get("host_dbus") is not False:
+        errors.append("topology.ha_addon.host_dbus must be false for current add-on negative DBus proof")
+    if addon.get("same_container_or_bridge_only") is not False:
+        errors.append("same-container or same-bridge proof is not sufficient")
+
+    if lan_peer.get("scope") != "external_lan":
+        errors.append("topology.lan_peer.scope must be external_lan")
+    if lan_peer.get("same_host") is not False:
+        errors.append("topology.lan_peer.same_host must be false")
+    if not _non_empty_string(lan_peer.get("address_ref")):
+        errors.append("topology.lan_peer.address_ref missing")
+
+    return errors
+
+
+def _validate_security(security: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    booleans = {
+        "wildcard_bind_allowed": False,
+        "unexpected_bridge_exposure": False,
+        "ingress_reachable": False,
+        "web_ui_reachable": False,
+        "vendor_restricted": False,
+    }
+    for key, expected in booleans.items():
+        if security.get(key) is not expected:
+            errors.append(f"security.{key} must be {str(expected).lower()}")
+    if security.get("admin_surface") != "none":
+        errors.append("security.admin_surface must be none for MSP-03C")
+    return errors
+
+
+def _validate_lab_run(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    lab = _dict(payload.get("lab"))
+    if not lab:
+        return ["lab_run artifacts require a lab object"]
+
+    required_strings = (
+        "repo_branch",
+        "addon_build_id",
+        "collector_command_log_ref",
+        "external_lan_peer_namespace_ref",
+        "listener_socket_ref",
+        "mdns_browse_ref",
+        "mdns_resolve_ref",
+        "restart_ref",
+        "collected_at",
+    )
+    for key in required_strings:
+        if not _non_empty_string(lab.get(key)):
+            errors.append(f"lab.{key} missing")
+
+    repo_commit = lab.get("repo_commit")
+    if not isinstance(repo_commit, str) or not GIT_SHA_RE.fullmatch(repo_commit):
+        errors.append("lab.repo_commit must be a 40-character lowercase git SHA")
+
+    if not (
+        _non_empty_string(lab.get("configured_interface_ref"))
+        or _non_empty_string(lab.get("configured_subnet_ref"))
+    ):
+        errors.append("lab requires configured_interface_ref or configured_subnet_ref")
+
+    evidence_ids = lab.get("case_evidence_ids")
+    if not isinstance(evidence_ids, dict):
+        errors.append("lab.case_evidence_ids must be an object")
+    else:
+        for case_id in REQUIRED_CASES:
+            ids = evidence_ids.get(case_id)
+            if not isinstance(ids, list) or not ids:
+                errors.append(f"lab.case_evidence_ids.{case_id} must be a non-empty list")
+                continue
+            if not all(_non_empty_string(item) for item in ids):
+                errors.append(f"lab.case_evidence_ids.{case_id} entries must be non-empty strings")
+            for item in ids:
+                if isinstance(item, str) and not LAB_EVIDENCE_RE.fullmatch(item):
+                    errors.append(
+                        f"lab.case_evidence_ids.{case_id} entry must be an msp03c evidence id or sha256:12hex",
+                    )
+
+    for key in ("collector_command_log_ref", "listener_socket_ref", "mdns_browse_ref", "mdns_resolve_ref", "restart_ref"):
+        value = lab.get(key)
+        if isinstance(value, str) and not LAB_EVIDENCE_RE.fullmatch(value):
+            errors.append(f"lab.{key} must be an msp03c evidence id or sha256:12hex")
+
+    return errors
+
+
+def _validate_credential_store(store: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if store.get("path") != "/data/eebus-proof":
+        errors.append("credential_store.path must be /data/eebus-proof")
+    if store.get("class") != "disposable_proof":
+        errors.append("credential_store.class must be disposable_proof")
+    if store.get("production_trust_written") is not False:
+        errors.append("credential_store.production_trust_written must be false")
+    if store.get("persistent_across_restart") is not True:
+        errors.append("credential_store.persistent_across_restart must be true")
+    if store.get("symlink_checked") is not True:
+        errors.append("credential_store.symlink_checked must be true")
+    if store.get("path_traversal_checked") is not True:
+        errors.append("credential_store.path_traversal_checked must be true")
+
+    permissions = _dict(store.get("permissions"))
+    if permissions.get("directory") != "0700":
+        errors.append("credential_store.permissions.directory must be 0700")
+    if permissions.get("files") != "0600":
+        errors.append("credential_store.permissions.files must be 0600")
+
+    pre = store.get("pre_restart_identity_ref")
+    post = store.get("post_restart_identity_ref")
+    if not _is_redacted_digest(pre):
+        errors.append("credential_store.pre_restart_identity_ref must be sha256:12hex")
+    if not _is_redacted_digest(post):
+        errors.append("credential_store.post_restart_identity_ref must be sha256:12hex")
+    if pre != post:
+        errors.append("credential_store identity ref must survive restart")
+
+    return errors
+
+
+def _validate_g05(case: dict[str, Any]) -> list[str]:
+    listener = _dict(case.get("listener"))
+    errors: list[str] = []
+    if listener.get("bind_policy") not in {"configured_interface", "configured_subnet"}:
+        errors.append("EEBUS-G05: listener.bind_policy must be configured_interface or configured_subnet")
+    if listener.get("wildcard_bind") is not False:
+        errors.append("EEBUS-G05: wildcard_bind must be false")
+    if listener.get("unexpected_bridge_exposure") is not False:
+        errors.append("EEBUS-G05: unexpected_bridge_exposure must be false")
+    if listener.get("lan_tcp_reachable") is not True:
+        errors.append("EEBUS-G05: lan_tcp_reachable must be true")
+    return errors
+
+
+def _validate_g06(case: dict[str, Any]) -> list[str]:
+    mdns = _dict(case.get("mdns"))
+    errors: list[str] = []
+    if mdns.get("lan_peer_resolved") is not True:
+        errors.append("EEBUS-G06: lan_peer_resolved must be true")
+    if mdns.get("peer_scope") != "external_lan":
+        errors.append("EEBUS-G06: peer_scope must be external_lan")
+    if mdns.get("service_type") != EXPECTED_SHIP_SERVICE_TYPE:
+        errors.append(f"EEBUS-G06: service_type must be {EXPECTED_SHIP_SERVICE_TYPE}")
+    return errors
+
+
+def _validate_g07(case: dict[str, Any]) -> list[str]:
+    negative = _dict(case.get("negative"))
+    errors: list[str] = []
+    if negative.get("mdns_disabled_absent") is not True:
+        errors.append("EEBUS-G07: mdns_disabled_absent must be true")
+    if negative.get("avahi_dbus_state") != "degraded_explicit":
+        errors.append("EEBUS-G07: avahi_dbus_state must be degraded_explicit")
+    if negative.get("pairing_closed_absent_or_ttl_expired") is not True:
+        errors.append("EEBUS-G07: pairing_closed_absent_or_ttl_expired must be true")
+    return errors
+
+
+def _validate_g08(case: dict[str, Any]) -> list[str]:
+    manual = _dict(case.get("manual_endpoint"))
+    errors: list[str] = []
+    if manual.get("configured") is not True:
+        errors.append("EEBUS-G08: manual_endpoint.configured must be true")
+    if manual.get("requires_discovery") is not False:
+        errors.append("EEBUS-G08: manual_endpoint.requires_discovery must be false")
+    if manual.get("reaches_peer_when_discovery_unavailable") is not True:
+        errors.append("EEBUS-G08: manual endpoint must reach peer when discovery is unavailable")
+    if manual.get("source") != "operator_config":
+        errors.append("EEBUS-G08: manual endpoint source must be operator_config")
+    return errors
+
+
+def _validate_g09(case: dict[str, Any], store: dict[str, Any]) -> list[str]:
+    persistence = _dict(case.get("credential_persistence"))
+    errors: list[str] = []
+    if persistence.get("store_path") != store.get("path"):
+        errors.append("EEBUS-G09: credential_persistence.store_path must match credential_store.path")
+    if persistence.get("disposable_only") is not True:
+        errors.append("EEBUS-G09: disposable_only must be true")
+    if persistence.get("survives_restart") is not True:
+        errors.append("EEBUS-G09: survives_restart must be true")
+    if persistence.get("production_trust_written") is not False:
+        errors.append("EEBUS-G09: production_trust_written must be false")
+    return errors
+
+
+def _validate_redaction(payload: Any) -> list[str]:
+    errors: list[str] = []
+    for path, value in _walk_strings(payload):
+        if SECRET_PATH_RE.search(path):
+            errors.append(f"{path}: secret-bearing key is forbidden")
+        if PEM_RE.search(value):
+            errors.append(f"{path}: PEM/private key material is forbidden")
+        if SECRET_VALUE_RE.search(value):
+            errors.append(f"{path}: secret-bearing value is forbidden")
+        if MAC_RE.search(value):
+            errors.append(f"{path}: MAC address is forbidden")
+        if SERIAL_RE.search(value):
+            errors.append(f"{path}: device serial-like value is forbidden")
+        for token in _find_ip_tokens(value):
+            if _is_forbidden_ip(token):
+                errors.append(f"{path}: raw IP address is forbidden")
+    return errors
+
+
+def _validate_unknown_fields(payload: dict[str, Any]) -> list[str]:
+    allowed = {
+        "$": {
+            "contract",
+            "issue",
+            "repo",
+            "generated_at",
+            "mode",
+            "result",
+            "required_cases",
+            "topology",
+            "security",
+            "credential_store",
+            "cases",
+            "lab",
+        },
+        "$.topology": {"ha_addon", "lan_peer"},
+        "$.topology.ha_addon": {
+            "host_network",
+            "host_dbus",
+            "same_container_or_bridge_only",
+            "network_namespace_ref",
+        },
+        "$.topology.lan_peer": {"scope", "same_host", "address_ref"},
+        "$.security": {
+            "wildcard_bind_allowed",
+            "unexpected_bridge_exposure",
+            "ingress_reachable",
+            "web_ui_reachable",
+            "vendor_restricted",
+            "admin_surface",
+        },
+        "$.credential_store": {
+            "path",
+            "class",
+            "production_trust_written",
+            "persistent_across_restart",
+            "symlink_checked",
+            "path_traversal_checked",
+            "permissions",
+            "pre_restart_identity_ref",
+            "post_restart_identity_ref",
+        },
+        "$.credential_store.permissions": {"directory", "files"},
+        "$.cases[]": {"id", "status", "evidence", "listener", "mdns", "negative", "manual_endpoint", "credential_persistence"},
+        "$.cases[].listener": {"bind_policy", "wildcard_bind", "unexpected_bridge_exposure", "lan_tcp_reachable"},
+        "$.cases[].mdns": {"lan_peer_resolved", "peer_scope", "service_type"},
+        "$.cases[].negative": {
+            "mdns_disabled_absent",
+            "avahi_dbus_state",
+            "pairing_closed_absent_or_ttl_expired",
+        },
+        "$.cases[].manual_endpoint": {
+            "configured",
+            "requires_discovery",
+            "reaches_peer_when_discovery_unavailable",
+            "source",
+        },
+        "$.cases[].credential_persistence": {
+            "store_path",
+            "disposable_only",
+            "survives_restart",
+            "production_trust_written",
+        },
+        "$.lab": {
+            "repo_branch",
+            "repo_commit",
+            "addon_build_id",
+            "collector_command_log_ref",
+            "external_lan_peer_namespace_ref",
+            "listener_socket_ref",
+            "mdns_browse_ref",
+            "mdns_resolve_ref",
+            "restart_ref",
+            "collected_at",
+            "configured_interface_ref",
+            "configured_subnet_ref",
+            "case_evidence_ids",
+        },
+        "$.lab.case_evidence_ids": set(REQUIRED_CASES),
+    }
+
+    errors: list[str] = []
+    for path, obj in _walk_dicts(payload):
+        normalized = _normalize_schema_path(path)
+        allowed_keys = allowed.get(normalized)
+        if allowed_keys is None:
+            continue
+        for key in obj:
+            if key in allowed_keys:
+                continue
+            if CONTRADICTION_KEY_RE.search(key):
+                errors.append(f"{path}.{key}: contradiction-prone extra field is forbidden")
+            else:
+                errors.append(f"{path}.{key}: unexpected field")
+    return errors
+
+
+def _walk_dicts(value: Any, path: str = "$"):
+    if isinstance(value, dict):
+        yield path, value
+        for key, child in value.items():
+            yield from _walk_dicts(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for idx, child in enumerate(value):
+            yield from _walk_dicts(child, f"{path}[{idx}]")
+
+
+def _normalize_schema_path(path: str) -> str:
+    return re.sub(r"\[\d+\]", "[]", path)
+
+
+def _walk_strings(value: Any, path: str = "$"):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from _walk_strings(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for idx, child in enumerate(value):
+            yield from _walk_strings(child, f"{path}[{idx}]")
+    elif isinstance(value, str):
+        yield path, value
+
+
+def _is_private_or_link_local_ip(value: str) -> bool:
+    try:
+        address = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return address.is_private or address.is_link_local or address.is_loopback
+
+
+def _find_ip_tokens(value: str) -> set[str]:
+    tokens: set[str] = set()
+    for match in re.findall(r"\b(?:(?:\d{1,3})\.){3}(?:\d{1,3})\b", value):
+        tokens.add(match)
+    for raw in re.findall(r"(?<![A-Za-z0-9])\[?[0-9A-Fa-f:.%]+\]?(?![A-Za-z0-9])", value):
+        candidate = raw.strip("[]().,;")
+        if ":" not in candidate:
+            continue
+        if "%" in candidate:
+            candidate = candidate.split("%", 1)[0]
+        try:
+            ipaddress.ip_address(candidate)
+        except ValueError:
+            continue
+        tokens.add(candidate)
+    return tokens
+
+
+def _is_forbidden_ip(value: str) -> bool:
+    try:
+        address = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return True
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _is_redacted_digest(value: Any) -> bool:
+    return isinstance(value, str) and bool(REDACTED_DIGEST_RE.fullmatch(value))
+
+
+def run_self_tests() -> int:
+    fixture_path = Path("scripts/fixtures/eebus_ha_network_proof_contract_pass.json")
+    payload = load_artifact(str(fixture_path))
+    baseline_errors = validate_artifact(payload, mode="contract")
+    if baseline_errors:
+        print(f"self-test baseline failed: {'; '.join(baseline_errors)}")
+        return 1
+
+    mutations = {
+        "wildcard bind rejected": lambda p: p["cases"][0]["listener"].__setitem__("wildcard_bind", True),
+        "same bridge rejected": lambda p: p["topology"]["ha_addon"].__setitem__(
+            "same_container_or_bridge_only",
+            True,
+        ),
+        "raw private IP rejected": lambda p: p["topology"]["lan_peer"].__setitem__(
+            "address_ref",
+            "192.168.1.44",
+        ),
+        "production trust rejected": lambda p: p["credential_store"].__setitem__(
+            "production_trust_written",
+            True,
+        ),
+        "manual endpoint discovery dependency rejected": lambda p: p["cases"][3][
+            "manual_endpoint"
+        ].__setitem__("requires_discovery", True),
+        "wrong mDNS service type rejected": lambda p: p["cases"][1]["mdns"].__setitem__(
+            "service_type",
+            "_eebus._tcp",
+        ),
+        "secret-bearing key rejected": lambda p: p.__setitem__("password", "hunter2"),
+        "bearer token rejected": lambda p: p["topology"]["lan_peer"].__setitem__(
+            "address_ref",
+            "Bearer abc.def.ghi",
+        ),
+        "IPv6 link-local rejected": lambda p: p["topology"]["lan_peer"].__setitem__(
+            "address_ref",
+            "fe80::1%eth0",
+        ),
+        "IPv6 ULA rejected": lambda p: p["topology"]["lan_peer"].__setitem__(
+            "address_ref",
+            "fd00::1",
+        ),
+        "IPv6 loopback rejected": lambda p: p["topology"]["lan_peer"].__setitem__(
+            "address_ref",
+            "::1",
+        ),
+        "IPv6 documentation address rejected": lambda p: p["topology"]["lan_peer"].__setitem__(
+            "address_ref",
+            "2001:db8::1",
+        ),
+        "wildcard contradiction field rejected": lambda p: p["cases"][0]["listener"].__setitem__(
+            "actual_bind",
+            "*:4712",
+        ),
+    }
+
+    for name, mutate in mutations.items():
+        mutated = copy.deepcopy(payload)
+        mutate(mutated)
+        errors = validate_artifact(mutated, mode="contract")
+        if not errors:
+            print(f"self-test mutation did not fail: {name}")
+            return 1
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp, "lab-required.json")
+        lab_required = copy.deepcopy(payload)
+        lab_required["mode"] = "contract_fixture"
+        tmp_path.write_text(json.dumps(lab_required), encoding="utf-8")
+        errors = validate_artifact(load_artifact(str(tmp_path)), mode="lab")
+        if not any("mode=lab_run" in error for error in errors):
+            print("self-test lab mode did not require mode=lab_run")
+            return 1
+
+        relabeled_fixture = copy.deepcopy(payload)
+        relabeled_fixture["mode"] = "lab_run"
+        tmp_path.write_text(json.dumps(relabeled_fixture), encoding="utf-8")
+        errors = validate_artifact(load_artifact(str(tmp_path)), mode="lab")
+        if not any("lab object" in error for error in errors):
+            print("self-test lab mode accepted relabeled contract fixture")
+            return 1
+
+        valid_lab = copy.deepcopy(payload)
+        valid_lab["mode"] = "lab_run"
+        valid_lab["lab"] = {
+            "repo_branch": "issue/166-msp-03c-ha-eebus-network-proof",
+            "repo_commit": "0123456789abcdef0123456789abcdef01234567",
+            "addon_build_id": "msp03c-addon-build",
+            "collector_command_log_ref": "msp03c-command-log-redacted",
+            "external_lan_peer_namespace_ref": "msp03c-peer-namespace-redacted",
+            "listener_socket_ref": "msp03c-listener-socket-redacted",
+            "mdns_browse_ref": "msp03c-mdns-browse-redacted",
+            "mdns_resolve_ref": "msp03c-mdns-resolve-redacted",
+            "restart_ref": "msp03c-restart-redacted",
+            "collected_at": "2026-07-08T00:00:00Z",
+            "configured_interface_ref": "msp03c-interface-redacted",
+            "case_evidence_ids": {
+                case_id: [f"msp03c-{case_id.lower()}-redacted"] for case_id in REQUIRED_CASES
+            },
+        }
+        tmp_path.write_text(json.dumps(valid_lab), encoding="utf-8")
+        errors = validate_artifact(load_artifact(str(tmp_path)), mode="lab")
+        if errors:
+            print(f"self-test valid lab fixture failed: {'; '.join(errors)}")
+            return 1
+
+    print("eeBUS HA network proof self-test: PASS")
+    return 0
+
+
+def main() -> int:
+    args = parse_args()
+    if args.self_test:
+        return run_self_tests()
+
+    try:
+        payload = load_artifact(args.artifact)
+    except (FileNotFoundError, json.JSONDecodeError, ValueError) as exc:
+        print(f"eeBUS HA network proof: FAIL ({exc})")
+        return 1
+
+    errors = validate_artifact(payload, mode=args.mode)
+    if errors:
+        print(f"eeBUS HA network proof: FAIL ({'; '.join(errors)})")
+        return 1
+
+    print(f"eeBUS HA network proof: PASS ({args.mode})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_markdown_private_ips.py
+++ b/scripts/check_markdown_private_ips.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Reject private IPv4 addresses in Markdown docs."""
+
+from __future__ import annotations
+
+import ipaddress
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+IPV4_RE = re.compile(r"\b(?:(?:\d{1,3})\.){3}(?:\d{1,3})\b")
+
+PRIVATE_NETS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("169.254.0.0/16"),
+]
+
+
+def is_private_ipv4(value: str) -> bool:
+    try:
+        address = ipaddress.ip_address(value)
+    except ValueError:
+        return False
+    return address.version == 4 and any(address in network for network in PRIVATE_NETS)
+
+
+def validate_markdown_private_ips() -> list[str]:
+    errors: list[str] = []
+    md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
+    for file_path in md_files:
+        text = Path(file_path).read_text(encoding="utf-8")
+        for match in IPV4_RE.finditer(text):
+            address = match.group(0)
+            if not is_private_ipv4(address):
+                continue
+            line = text.count("\n", 0, match.start()) + 1
+            errors.append(f"{file_path}:{line}: private IPv4 address found (use a placeholder)")
+    return errors
+
+
+def run_self_test() -> int:
+    if not IPV4_RE.search("192.168.1.1"):
+        print("self-test failed: IPv4 regex did not match private address")
+        return 1
+    if not is_private_ipv4("192.168.1.1"):
+        print("self-test failed: private IPv4 not detected")
+        return 1
+    if not is_private_ipv4("100.64.1.1"):
+        print("self-test failed: CGNAT IPv4 not detected")
+        return 1
+    if is_private_ipv4("203.0.113.10"):
+        print("self-test failed: documentation IPv4 placeholder rejected")
+        return 1
+    print("Private IPv4 gate self-test passed.")
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--self-test":
+        return run_self_test()
+    errors = validate_markdown_private_ips()
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+    print("Private IPv4 gate passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -37,6 +37,10 @@ fi
 echo "==> validate smoke runbook structure"
 python3 scripts/validate_smoke_docs.py
 
+echo "==> eeBUS HA network proof contract"
+python3 scripts/check_eebus_ha_network_proof.py --self-test
+python3 scripts/check_eebus_ha_network_proof.py --artifact scripts/fixtures/eebus_ha_network_proof_contract_pass.json --mode contract
+
 echo "==> source address wrapper migration"
 python3 scripts/check_source_addr_wrapper.py
 
@@ -50,48 +54,5 @@ echo "==> post-parity enablement tasks"
 python3 scripts/run_post_parity_enablement.py --guardrail helianthus/rollout_guardrails.json --artifact scripts/fixtures/gateway_parity_artifact_pass.json --addon-config helianthus/config.json --smoke-runbook SMOKE_RUNBOOK.md
 
 echo "==> private IPv4 address gate (docs must use placeholders)"
-python3 - <<'PY'
-from __future__ import annotations
-
-import ipaddress
-import pathlib
-import re
-import subprocess
-import sys
-
-md_files = subprocess.check_output(["git", "ls-files", "*.md"], text=True).splitlines()
-ipv4_re = re.compile(r"\\b(?:(?:\\d{1,3})\\.){3}(?:\\d{1,3})\\b")
-
-PRIVATE_NETS = [
-    ipaddress.ip_network("10.0.0.0/8"),
-    ipaddress.ip_network("172.16.0.0/12"),
-    ipaddress.ip_network("192.168.0.0/16"),
-    ipaddress.ip_network("100.64.0.0/10"),  # CGNAT
-    ipaddress.ip_network("169.254.0.0/16"),  # link-local
-]
-
-def is_private_ipv4(ip: str) -> bool:
-    try:
-        addr = ipaddress.ip_address(ip)
-    except ValueError:
-        return False
-    if addr.version != 4:
-        return False
-    return any(addr in net for net in PRIVATE_NETS)
-
-failed = False
-
-for file_path in md_files:
-    text = pathlib.Path(file_path).read_text(encoding="utf-8")
-    for match in ipv4_re.finditer(text):
-        ip = match.group(0)
-        if not is_private_ipv4(ip):
-            continue
-        line = text.count("\n", 0, match.start()) + 1
-        print(f"{file_path}:{line}: private IPv4 address found (use a placeholder)", file=sys.stderr)
-        failed = True
-
-if failed:
-    sys.exit(1)
-print("Private IPv4 gate passed.")
-PY
+python3 scripts/check_markdown_private_ips.py --self-test
+python3 scripts/check_markdown_private_ips.py

--- a/scripts/fixtures/eebus_ha_network_proof_contract_pass.json
+++ b/scripts/fixtures/eebus_ha_network_proof_contract_pass.json
@@ -1,0 +1,119 @@
+{
+  "contract": "helianthus.eebus.ha-network-proof.v0",
+  "issue": "MSP-03C",
+  "repo": "Project-Helianthus/helianthus-ha-addon",
+  "generated_at": "2026-07-08T00:00:00Z",
+  "mode": "contract_fixture",
+  "result": "PASS",
+  "required_cases": [
+    "EEBUS-G05",
+    "EEBUS-G06",
+    "EEBUS-G07",
+    "EEBUS-G08",
+    "EEBUS-G09"
+  ],
+  "topology": {
+    "ha_addon": {
+      "host_network": true,
+      "host_dbus": false,
+      "same_container_or_bridge_only": false,
+      "network_namespace_ref": "ha-supervisor-host-network-redacted"
+    },
+    "lan_peer": {
+      "scope": "external_lan",
+      "same_host": false,
+      "address_ref": "lan-peer-redacted"
+    }
+  },
+  "security": {
+    "wildcard_bind_allowed": false,
+    "unexpected_bridge_exposure": false,
+    "ingress_reachable": false,
+    "web_ui_reachable": false,
+    "vendor_restricted": false,
+    "admin_surface": "none"
+  },
+  "credential_store": {
+    "path": "/data/eebus-proof",
+    "class": "disposable_proof",
+    "production_trust_written": false,
+    "persistent_across_restart": true,
+    "symlink_checked": true,
+    "path_traversal_checked": true,
+    "permissions": {
+      "directory": "0700",
+      "files": "0600"
+    },
+    "pre_restart_identity_ref": "sha256:0123456789ab",
+    "post_restart_identity_ref": "sha256:0123456789ab"
+  },
+  "cases": [
+    {
+      "id": "EEBUS-G05",
+      "status": "PASS",
+      "evidence": [
+        "listener bound to configured interface/subnet",
+        "LAN TCP reachability recorded from external peer",
+        "bridge and wildcard exposure checks recorded"
+      ],
+      "listener": {
+        "bind_policy": "configured_interface",
+        "wildcard_bind": false,
+        "unexpected_bridge_exposure": false,
+        "lan_tcp_reachable": true
+      }
+    },
+    {
+      "id": "EEBUS-G06",
+      "status": "PASS",
+      "evidence": [
+        "external LAN peer browsed and resolved the advertised service"
+      ],
+      "mdns": {
+        "lan_peer_resolved": true,
+        "peer_scope": "external_lan",
+        "service_type": "_ship._tcp"
+      }
+    },
+    {
+      "id": "EEBUS-G07",
+      "status": "PASS",
+      "evidence": [
+        "mDNS disabled case produced absent service",
+        "host DBus/Avahi unavailable state recorded as explicit degraded state",
+        "closed pairing window produced absent or TTL-expired advertisement"
+      ],
+      "negative": {
+        "mdns_disabled_absent": true,
+        "avahi_dbus_state": "degraded_explicit",
+        "pairing_closed_absent_or_ttl_expired": true
+      }
+    },
+    {
+      "id": "EEBUS-G08",
+      "status": "PASS",
+      "evidence": [
+        "manual endpoint reached peer with discovery disabled"
+      ],
+      "manual_endpoint": {
+        "configured": true,
+        "requires_discovery": false,
+        "reaches_peer_when_discovery_unavailable": true,
+        "source": "operator_config"
+      }
+    },
+    {
+      "id": "EEBUS-G09",
+      "status": "PASS",
+      "evidence": [
+        "disposable proof credential identity survived proof restart"
+      ],
+      "credential_persistence": {
+        "store_path": "/data/eebus-proof",
+        "disposable_only": true,
+        "survives_restart": true,
+        "production_trust_written": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What
Adds the MSP-03C eeBUS HA add-on network proof gate and redacted artifact validator.

## Why
M3 needs a deterministic contract for EEBUS-G05..G09 before black-box fake peer and live VR940f smoke proceed. This PR does not enable eeBUS runtime, add production config, start listeners, or write trust.

## Verification
- python3 scripts/check_eebus_ha_network_proof.py --self-test
- python3 scripts/check_eebus_ha_network_proof.py --artifact scripts/fixtures/eebus_ha_network_proof_contract_pass.json --mode contract
- python3 scripts/check_markdown_private_ips.py --self-test
- python3 scripts/check_markdown_private_ips.py
- ./scripts/ci_local.sh
- python3 -m pytest tests/test_runtime_state_wrapper_red.py tests/test_source_addr_wrapper_m4.py -q
- git diff --check

## Review
- GPT-5.5 xhigh security re-review: clear
- GPT-5.5 high transport re-review: clear
- gpt-5.4-mini docs/CI re-review: clear

Doc-gate: Project-Helianthus/helianthus-docs-ebus#338 merged.

Closes #166