### PR TITLE
fix: bind Modbus health to runtime readiness

### DIFF
--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -997,6 +997,19 @@ if [ "${#fallback_proxy_listen_args[@]}" -ne 0 ]; then modbus_fallback_args+=("$
 
 modbus_passed_startup_window=false
 
+modbus_runtime_ready() {
+  local readiness_args
+  readiness_args=(
+    probe-readiness
+    --listener "${http_addr}"
+    --timeout-ms 250
+  )
+  if [ "${#proxy_listen_args[@]}" -ne 0 ]; then
+    readiness_args+=(--listener "${proxy_listen_addr}")
+  fi
+  python3 "${modbus_guard}" "${readiness_args[@]}" >/dev/null 2>&1
+}
+
 modbus_run_current() {
   local attempt_started elapsed rc ready_checks
   modbus_passed_startup_window=false
@@ -1069,6 +1082,12 @@ modbus_run_current() {
     fi
     elapsed=$(( $(date +%s) - attempt_started ))
     if ! bashio::var.true "${modbus_passed_startup_window}" && [ "${elapsed}" -ge "${modbus_startup_window_seconds}" ]; then
+      if ! modbus_runtime_ready; then
+        modbus_runtime_failure_reason=RUNTIME_NOT_READY
+        modbus_terminate_child
+        modbus_cleanup_redactors || true
+        return 124
+      fi
       modbus_passed_startup_window=true
       modbus_write_health RUNNING "${attempt}" current STARTUP_WINDOW_PASSED
     fi
@@ -1087,6 +1106,7 @@ modbus_run_current() {
 modbus_run_fallback() {
   local attempt_started elapsed rc
   modbus_passed_startup_window=false
+  modbus_runtime_failure_reason=""
   if bashio::var.true "${modbus_stop_requested}"; then
     return 143
   fi
@@ -1101,6 +1121,11 @@ modbus_run_fallback() {
   while kill -0 "${modbus_child_pid}" 2>/dev/null; do
     elapsed=$(( $(date +%s) - attempt_started ))
     if [ "${elapsed}" -ge "${modbus_startup_window_seconds}" ]; then
+      if ! modbus_runtime_ready; then
+        modbus_runtime_failure_reason=FALLBACK_RUNTIME_NOT_READY
+        modbus_terminate_child
+        return 124
+      fi
       modbus_passed_startup_window=true
       modbus_write_health FALLBACK_ACTIVE "${MODBUS_RECOVERY_MAX_ATTEMPTS}" fallback STARTUP_WINDOW_PASSED
       break
@@ -1148,6 +1173,6 @@ fi
 if bashio::var.true "${modbus_passed_startup_window}"; then
   modbus_write_health FALLBACK_EXITED "${MODBUS_RECOVERY_MAX_ATTEMPTS}" fallback FALLBACK_RUNTIME_EXIT
 else
-  modbus_write_health FALLBACK_EXITED "${MODBUS_RECOVERY_MAX_ATTEMPTS}" fallback FALLBACK_STARTUP_EXIT
+  modbus_write_health FALLBACK_EXITED "${MODBUS_RECOVERY_MAX_ATTEMPTS}" fallback "${modbus_runtime_failure_reason:-FALLBACK_STARTUP_EXIT}"
 fi
 exit "${rc}"

--- a/helianthus/rootfs/usr/share/helianthus/modbus_runtime_guard.py
+++ b/helianthus/rootfs/usr/share/helianthus/modbus_runtime_guard.py
@@ -12,6 +12,7 @@ import math
 import os
 import re
 import shlex
+import socket
 import sys
 import tempfile
 from dataclasses import dataclass
@@ -22,6 +23,8 @@ from urllib.parse import urlsplit
 CONTRACT = "helianthus.modbus-addon-health.v1"
 MAX_DIAL_TIMEOUT_MS = 30_000
 MIN_DIAL_TIMEOUT_MS = 100
+MIN_READINESS_TIMEOUT_MS = 10
+MAX_READINESS_TIMEOUT_MS = 2_000
 _DURATION_RE = re.compile(r"^([1-9][0-9]*)(ms|s)$")
 _HOST_LABEL_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
 _STATES = {
@@ -194,6 +197,46 @@ def clear_health_file(path: Path) -> None:
         path.unlink()
 
 
+def _readiness_target(value: str) -> tuple[str, int]:
+    if not value or value != value.strip() or "://" in value:
+        raise ConfigError("invalid listener")
+    candidate = "0.0.0.0" + value if value.startswith(":") else value
+    try:
+        parsed = urlsplit("tcp://" + candidate)
+        port = parsed.port
+    except ValueError as error:
+        raise ConfigError("invalid listener") from error
+    host = parsed.hostname or ""
+    if (
+        parsed.username is not None
+        or parsed.password is not None
+        or not host
+        or port is None
+        or not 1 <= port <= 65535
+        or not _valid_host(host)
+    ):
+        raise ConfigError("invalid listener")
+    if host == "0.0.0.0":
+        host = "127.0.0.1"
+    elif host == "::":
+        host = "::1"
+    return host, port
+
+
+def _probe_readiness_command(args: argparse.Namespace) -> int:
+    if not MIN_READINESS_TIMEOUT_MS <= args.timeout_ms <= MAX_READINESS_TIMEOUT_MS:
+        raise ConfigError("invalid readiness timeout")
+    timeout = args.timeout_ms / 1000
+    for listener in args.listener:
+        target = _readiness_target(listener)
+        try:
+            with socket.create_connection(target, timeout=timeout):
+                pass
+        except OSError:
+            return 1
+    return 0
+
+
 def _shell_assignment(name: str, value: str) -> str:
     return f"{name}={shlex.quote(value)}"
 
@@ -305,6 +348,11 @@ def parser() -> argparse.ArgumentParser:
     clear_runtime.add_argument("--endpoint-file", type=Path, required=True)
     clear_runtime.add_argument("--health", type=Path, required=True)
     clear_runtime.set_defaults(handler=_clear_runtime_command)
+
+    readiness = commands.add_parser("probe-readiness")
+    readiness.add_argument("--listener", action="append", required=True)
+    readiness.add_argument("--timeout-ms", type=int, default=250)
+    readiness.set_defaults(handler=_probe_readiness_command)
 
     redact = commands.add_parser("redact")
     redact.add_argument("--endpoint-file", type=Path, required=True)

--- a/helianthus/rootfs/usr/share/helianthus/modbus_runtime_guard.py
+++ b/helianthus/rootfs/usr/share/helianthus/modbus_runtime_guard.py
@@ -213,14 +213,17 @@ def _readiness_target(value: str) -> tuple[str, int]:
         or not host
         or port is None
         or not 1 <= port <= 65535
-        or not _valid_host(host)
     ):
         raise ConfigError("invalid listener")
-    if host == "0.0.0.0":
-        host = "127.0.0.1"
-    elif host == "::":
-        host = "::1"
-    return host, port
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError as error:
+        raise ConfigError("listener host must be numeric") from error
+    if address == ipaddress.ip_address("0.0.0.0"):
+        address = ipaddress.ip_address("127.0.0.1")
+    elif address == ipaddress.ip_address("::"):
+        address = ipaddress.ip_address("::1")
+    return str(address), port
 
 
 def _probe_readiness_command(args: argparse.Namespace) -> int:

--- a/tests/test_modbus_runtime_guard.py
+++ b/tests/test_modbus_runtime_guard.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 import os
 import signal
+import socket
 import stat
 import subprocess
 import sys
@@ -311,6 +312,55 @@ def test_health_is_atomic_private_deterministic_and_redacted(tmp_path: Path) -> 
     assert not list(tmp_path.glob("*.tmp"))
 
 
+def test_readiness_probe_requires_every_declared_local_listener() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen()
+        ready_port = listener.getsockname()[1]
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as unused:
+            unused.bind(("127.0.0.1", 0))
+            missing_port = unused.getsockname()[1]
+
+        ready = subprocess.run(
+            [
+                sys.executable,
+                str(GUARD_PATH),
+                "probe-readiness",
+                "--listener",
+                f"0.0.0.0:{ready_port}",
+                "--timeout-ms",
+                "200",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        incomplete = subprocess.run(
+            [
+                sys.executable,
+                str(GUARD_PATH),
+                "probe-readiness",
+                "--listener",
+                f"0.0.0.0:{ready_port}",
+                "--listener",
+                f"127.0.0.1:{missing_port}",
+                "--timeout-ms",
+                "200",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    assert ready.returncode == 0, ready.stderr
+    assert ready.stdout == ""
+    assert ready.stderr == ""
+    assert incomplete.returncode != 0
+    assert incomplete.stdout == ""
+    assert incomplete.stderr == ""
+
+
 def test_image_and_wrapper_wire_current_plus_fallback_without_modbus_leak() -> None:
     dockerfile = DOCKERFILE_PATH.read_text(encoding="utf-8")
     run = RUN_PATH.read_text(encoding="utf-8")
@@ -428,6 +478,8 @@ def run_wrapper(
     startup_delay_before_gateway_launch: float = 0,
     record_health_calls: bool = False,
     registration_delay_target: str | None = None,
+    readiness_result: bool = True,
+    startup_window_seconds_override: int | None = None,
 ) -> subprocess.CompletedProcess[str]:
     current = tmp_path / "gateway-current"
     fallback = tmp_path / "gateway-fallback"
@@ -446,6 +498,12 @@ def run_wrapper(
     run = run.replace("/usr/local/bin/helianthus-gateway", "${TEST_CURRENT_GATEWAY_BIN}")
     run = run.replace("/data/helianthus-gateway", "${TEST_OVERRIDE_GATEWAY_BIN}")
     run = run.replace("/data/source_addr.last", "${TEST_SOURCE_STATE_FILE}")
+    if startup_window_seconds_override is not None:
+        run = run.replace(
+            'modbus_startup_window_seconds="${MODBUS_STARTUP_WINDOW_SECONDS}"',
+            f"modbus_startup_window_seconds={startup_window_seconds_override}",
+            1,
+        )
     if startup_delay_before_disabled_launch:
         run = run.replace(
             'if ! bashio::var.true "${modbus_tcp_enabled}"; then',
@@ -518,6 +576,7 @@ def run_wrapper(
         or redactor_exit_after_ready is not None
         or record_health_calls
         or registration_delay_target is not None
+        or not readiness_result
     ):
         guard_path = tmp_path / "guard-proxy.py"
         guard_path.write_text(
@@ -530,6 +589,9 @@ from pathlib import Path
 
 is_redactor = len(sys.argv) > 1 and sys.argv[1] == "redact"
 is_validator = len(sys.argv) > 1 and sys.argv[1] == "validate"
+is_readiness_probe = len(sys.argv) > 1 and sys.argv[1] == "probe-readiness"
+if is_readiness_probe:
+    raise SystemExit(0 if {readiness_result!r} else 1)
 if is_validator:
     Path({str(tmp_path / "validator-pid")!r}).write_text(str(os.getpid()), encoding="utf-8")
     time.sleep({validator_delay!r})
@@ -683,6 +745,35 @@ def test_wrapper_retries_three_times_then_runs_previous_binary_without_modbus(
     assert health["binary"] == "fallback"
     assert health["attempt"] == 3
     assert health["reason"] == "FALLBACK_STARTUP_EXIT"
+
+
+def test_listener_readiness_failure_never_publishes_running_and_reaps_binaries(
+    tmp_path: Path,
+) -> None:
+    result = run_wrapper(
+        tmp_path,
+        enabled_options(modbus_tcp_dial_timeout="100ms"),
+        current_sleep=3,
+        fallback_sleep=3,
+        readiness_result=False,
+        startup_window_seconds_override=1,
+        record_health_calls=True,
+        wrapper_timeout=15,
+    )
+
+    assert result.returncode != 0
+    assert (tmp_path / "current-count").read_text(encoding="utf-8") == "3"
+    health_calls = (tmp_path / "health-calls").read_text(encoding="utf-8").splitlines()
+    assert "RUNNING" not in health_calls
+    assert "FALLBACK_ACTIVE" not in health_calls
+    health = json.loads((tmp_path / "health.json").read_text(encoding="utf-8"))
+    assert health["state"] == "FALLBACK_EXITED"
+    assert health["reason"] == "FALLBACK_RUNTIME_NOT_READY"
+    assert not (tmp_path / "modbus-endpoint").exists()
+    for pid_file in (tmp_path / "child-pid", tmp_path / "fallback-pid"):
+        pid = int(pid_file.read_text(encoding="utf-8"))
+        with pytest.raises(ProcessLookupError):
+            os.kill(pid, 0)
 
 
 def test_wrapper_disabled_path_runs_current_once_without_modbus_or_fallback(

--- a/tests/test_modbus_runtime_guard.py
+++ b/tests/test_modbus_runtime_guard.py
@@ -354,6 +354,20 @@ def test_readiness_probe_requires_every_declared_local_listener() -> None:
             capture_output=True,
             check=False,
         )
+        hostname = subprocess.run(
+            [
+                sys.executable,
+                str(GUARD_PATH),
+                "probe-readiness",
+                "--listener",
+                f"localhost:{ready_port}",
+                "--timeout-ms",
+                "200",
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
 
     assert ready.returncode == 0, ready.stderr
     assert ready.stdout == ""
@@ -361,6 +375,8 @@ def test_readiness_probe_requires_every_declared_local_listener() -> None:
     assert incomplete.returncode != 0
     assert incomplete.stdout == ""
     assert incomplete.stderr == ""
+    assert hostname.returncode != 0
+    assert "localhost" not in hostname.stdout + hostname.stderr
 
 
 def test_image_and_wrapper_wire_current_plus_fallback_without_modbus_leak() -> None:

--- a/tests/test_modbus_runtime_guard.py
+++ b/tests/test_modbus_runtime_guard.py
@@ -39,7 +39,9 @@ bashio::config() {
     subscription_path) printf '%s\n' "/graphql/subscriptions" ;;
     mcp_path) printf '%s\n' "/mcp" ;;
     mdns|broadcast|observe_first_enabled|passive_state_direct_apply) printf '%s\n' "true" ;;
-    passive_config_direct_apply|enable_static_seed_table|adapter_direct_enabled|eebus_enabled) printf '%s\n' "false" ;;
+    passive_config_direct_apply|enable_static_seed_table|eebus_enabled) printf '%s\n' "false" ;;
+    adapter_direct_enabled) printf '%s\n' "${TEST_ADAPTER_DIRECT_ENABLED:-false}" ;;
+    adapter_direct_address) printf '%s\n' "192.0.2.80:9999" ;;
     eebus_discovery_enabled) printf '%s\n' "true" ;;
     mdns_instance) printf '%s\n' "helianthus" ;;
     source_addr) printf '%s\n' "auto" ;;
@@ -444,7 +446,7 @@ import time
 from pathlib import Path
 
 if "--help" in sys.argv:
-    sys.stderr.write("Usage of gateway:\\n  -modbus-tcp-enabled\\n  -modbus-tcp-endpoint-file string\\n  -modbus-tcp-dial-timeout duration\\n{optional_help_text}")
+    sys.stderr.write("Usage of gateway:\\n  -modbus-tcp-enabled\\n  -modbus-tcp-endpoint-file string\\n  -modbus-tcp-dial-timeout duration\\n  -proxy-listen string\\n{optional_help_text}")
     raise SystemExit(0)
 {body}
 '''
@@ -478,8 +480,9 @@ def run_wrapper(
     startup_delay_before_gateway_launch: float = 0,
     record_health_calls: bool = False,
     registration_delay_target: str | None = None,
-    readiness_result: bool = True,
+    readiness_result: bool | None = True,
     startup_window_seconds_override: int | None = None,
+    adapter_direct_enabled: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     current = tmp_path / "gateway-current"
     fallback = tmp_path / "gateway-fallback"
@@ -576,7 +579,7 @@ def run_wrapper(
         or redactor_exit_after_ready is not None
         or record_health_calls
         or registration_delay_target is not None
-        or not readiness_result
+        or readiness_result is not None
     ):
         guard_path = tmp_path / "guard-proxy.py"
         guard_path.write_text(
@@ -590,7 +593,9 @@ from pathlib import Path
 is_redactor = len(sys.argv) > 1 and sys.argv[1] == "redact"
 is_validator = len(sys.argv) > 1 and sys.argv[1] == "validate"
 is_readiness_probe = len(sys.argv) > 1 and sys.argv[1] == "probe-readiness"
-if is_readiness_probe:
+if is_readiness_probe and {readiness_result is not None!r}:
+    with Path({str(tmp_path / "readiness-calls")!r}).open("a", encoding="utf-8") as handle:
+        handle.write("\\n".join(sys.argv[2:]) + "\\nCALL\\n")
     raise SystemExit(0 if {readiness_result!r} else 1)
 if is_validator:
     Path({str(tmp_path / "validator-pid")!r}).write_text(str(os.getpid()), encoding="utf-8")
@@ -653,6 +658,7 @@ except SystemExit as error:
             "TEST_FALLBACK_EXIT": str(fallback_exit),
             "TEST_FALLBACK_SLEEP": str(fallback_sleep),
             "TEST_PARENT_SIGNAL": str(signal_parent.value) if signal_parent else "",
+            "TEST_ADAPTER_DIRECT_ENABLED": "true" if adapter_direct_enabled else "false",
             "HELIANTHUS_RUNTIME_STATE_WRAPPER": str(
                 ROOT
                 / "helianthus/rootfs/usr/share/helianthus/check_runtime_state_wrapper.py"
@@ -774,6 +780,30 @@ def test_listener_readiness_failure_never_publishes_running_and_reaps_binaries(
         pid = int(pid_file.read_text(encoding="utf-8"))
         with pytest.raises(ProcessLookupError):
             os.kill(pid, 0)
+
+
+def test_adapter_direct_requires_http_and_proxy_listener_readiness(tmp_path: Path) -> None:
+    result = run_wrapper(
+        tmp_path,
+        enabled_options(modbus_tcp_dial_timeout="100ms"),
+        current_exit=0,
+        current_sleep=2,
+        startup_window_seconds_override=1,
+        adapter_direct_enabled=True,
+        wrapper_timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    readiness_calls = (tmp_path / "readiness-calls").read_text(encoding="utf-8")
+    assert readiness_calls.splitlines() == [
+        "--listener",
+        "0.0.0.0:8080",
+        "--timeout-ms",
+        "250",
+        "--listener",
+        "0.0.0.0:19001",
+        "CALL",
+    ]
 
 
 def test_wrapper_disabled_path_runs_current_once_without_modbus_or_fallback(


### PR DESCRIPTION
Closes #202

## Scope
- require bounded local listener readiness before `RUNNING` / `FALLBACK_ACTIVE`
- require gateway HTTP always and adapter proxy only when adapter-direct configures it
- restrict probe targets to numeric IPv4/bracketed IPv6 bind addresses; map wildcards to loopback and perform no DNS
- fail closed through existing retry/fallback lifecycle and reap both binaries
- no version bump, release, deploy, or live mutation

## TDD
- initial RED `3f7edec1ec3c876c837e332ccf42457feec506e6`: readiness command absent; process survival alone publishes false RUNNING
- initial GREEN `2804e2258639348518736a823362b07ab239669d`
- review RED `bb334c872ffb14a610bb7e41c6fcf67f69a6099c`: hostname target reaches DNS-capable socket path
- final GREEN: numeric-only bounded listener targets

## Docs gate
- Project-Helianthus/helianthus-docs-ebus#451 merged at `d7fb9b4200bb43f589ce540235eeb1159c79e0ad`

## Dependencies
- gateway endpoint ownership/redaction fix #830 merged at `225f3d96fee3422bc565870f946af19fac42d471`

## Boundaries
- deployment and live qualification remain hard-stopped
- release/version repin is a separate node