### PR TITLE
Add explicit adapter-direct ENS/ENH protocol selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ modbus_tcp_dial_timeout: 5s
 
 ```yaml
 adapter_direct_enabled: true
-adapter_direct_address: enh://203.0.113.10:9999
+adapter_direct_protocol: enh
+adapter_direct_address: 203.0.113.10:9999
 proxy_listen_addr: 0.0.0.0:19001
 transport: enh
 network: tcp
@@ -105,6 +106,13 @@ modbus_tcp_enabled: false
 modbus_tcp_endpoint: ""
 modbus_tcp_dial_timeout: 5s
 ```
+
+`adapter_direct_protocol` is the sole ENH/ENS selector for the physical adapter:
+`enh` emits `adapter-direct://HOST:PORT`, while `ens` emits
+`adapter-direct-ens://HOST:PORT`. Keep `proxy_profile=disabled` in
+adapter-direct mode; `proxy_profile` is reserved for an external proxy endpoint.
+The integrated proxy listener remains available through `proxy_listen_addr` for
+both adapter protocols.
 
 ### 5) Post-start operator smoke checks
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ ha addons repo add https://github.com/Project-Helianthus/helianthus-ha-addon
 ```
 
 Then install **Helianthus** from the Add-on Store and open add-on configuration.
-Release `0.6.48` packages the consolidated gateway with bounded FM5 startup
+Release `0.6.49` packages the consolidated gateway with bounded FM5 startup
 convergence, source-owned endpoint sanitization, and protocol-local Modbus
 startup failure. Enabled and disabled Modbus configurations use the same direct
 gateway `exec` lifecycle; Modbus remains disabled by default.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ adapter-direct mode; `proxy_profile` is reserved for an external proxy endpoint.
 The integrated proxy listener remains available through `proxy_listen_addr` for
 both adapter protocols.
 
+Upgrade compatibility is deterministic: a pre-selector adapter-direct
+configuration with `proxy_profile=enh|ens` and an empty `proxy_endpoint` is
+migrated at startup to the matching adapter-direct protocol, then treated as
+`proxy_profile=disabled`. Save the explicit `adapter_direct_protocol` and
+`proxy_profile=disabled` values after upgrading. A populated `proxy_endpoint`
+is a real external-proxy configuration and remains invalid with adapter-direct.
+
 ### 5) Post-start operator smoke checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -114,12 +114,15 @@ adapter-direct mode; `proxy_profile` is reserved for an external proxy endpoint.
 The integrated proxy listener remains available through `proxy_listen_addr` for
 both adapter protocols.
 
-Upgrade compatibility is deterministic: a pre-selector adapter-direct
-configuration with `proxy_profile=enh|ens` and an empty `proxy_endpoint` is
-migrated at startup to the matching adapter-direct protocol, then treated as
-`proxy_profile=disabled`. Save the explicit `adapter_direct_protocol` and
-`proxy_profile=disabled` values after upgrading. A populated `proxy_endpoint`
-is a real external-proxy configuration and remains invalid with adapter-direct.
+Upgrade compatibility is deterministic: when persisted options do not yet
+contain `adapter_direct_protocol`, a pre-selector adapter-direct configuration
+with `proxy_profile=enh|ens` and an empty `proxy_endpoint` is migrated at
+startup to the matching adapter-direct protocol, then treated as
+`proxy_profile=disabled`. Once the typed key is persisted, it is authoritative
+even if a stale empty-endpoint profile remains. Save the explicit
+`adapter_direct_protocol` and `proxy_profile=disabled` values after upgrading.
+A populated `proxy_endpoint` is a real external-proxy configuration and remains
+invalid with adapter-direct.
 
 ### 5) Post-start operator smoke checks
 

--- a/SMOKE_RUNBOOK.md
+++ b/SMOKE_RUNBOOK.md
@@ -32,12 +32,14 @@ For ENS, keep the same address and listener, set
 `adapter_direct_protocol=ens`, and expect
 `Transport: adapter-direct (tcp adapter-direct-ens://203.0.113.10:9999)`.
 
-An upgraded pre-selector configuration may still contain
-`proxy_profile=enh|ens` with an empty `proxy_endpoint`. Startup must log the
-legacy migration, emit the matching adapter-direct URI, report
-`Proxy profile: disabled`, and preserve `-proxy-listen`. Save the explicit
-`adapter_direct_protocol` and `proxy_profile=disabled` options afterward. If
-`proxy_endpoint` is populated, startup must reject the mixed configuration.
+An upgraded pre-selector configuration whose persisted options do not yet
+contain `adapter_direct_protocol` may still contain `proxy_profile=enh|ens`
+with an empty `proxy_endpoint`. Startup must log the legacy migration, emit the
+matching adapter-direct URI, report `Proxy profile: disabled`, and preserve
+`-proxy-listen`. Once the typed key exists, verify that it wins over any stale
+empty-endpoint profile. Save the explicit `adapter_direct_protocol` and
+`proxy_profile=disabled` options afterward. If `proxy_endpoint` is populated,
+startup must reject the mixed configuration.
 
 ## Install and start add-on
 

--- a/SMOKE_RUNBOOK.md
+++ b/SMOKE_RUNBOOK.md
@@ -19,12 +19,18 @@ the embedded gateway adaptermux proxy topology, and produces deterministic pass/
 ## Embedded adaptermux proxy topology
 
 - Point the Helianthus add-on at the physical adapter with `adapter_direct_enabled=true`.
+- Select the physical adapter protocol explicitly with `adapter_direct_protocol=enh|ens`.
 - Use `proxy_listen_addr` to expose the gateway-embedded adaptermux proxy for other clients.
 - Keep `proxy_profile=disabled`; the add-on no longer starts or wires a standalone adapter-proxy.
 - Example values:
-  - adapter direct address: `enh://203.0.113.10:9999`
+  - adapter direct protocol: `enh`
+  - adapter direct address: `203.0.113.10:9999`
   - proxy listener: `0.0.0.0:19001`
   - effective transport marker: `Transport: adapter-direct (tcp adapter-direct://203.0.113.10:9999)`
+
+For ENS, keep the same address and listener, set
+`adapter_direct_protocol=ens`, and expect
+`Transport: adapter-direct (tcp adapter-direct-ens://203.0.113.10:9999)`.
 
 ## Install and start add-on
 

--- a/SMOKE_RUNBOOK.md
+++ b/SMOKE_RUNBOOK.md
@@ -51,7 +51,7 @@ ha addons repo add https://github.com/Project-Helianthus/helianthus-ha-addon
 
 2) Install and start the `helianthus` add-on from Home Assistant Add-on Store.
 
-For release `0.6.48`, do not supply any eeBUS-specific credential options:
+For release `0.6.49`, do not supply any eeBUS-specific credential options:
 they remain removed. The consolidated runtime includes bounded FM5 startup
 convergence and source-owned endpoint sanitization. Modbus remains opt-in and
 uses the same direct gateway process lifecycle as the disabled configuration.

--- a/SMOKE_RUNBOOK.md
+++ b/SMOKE_RUNBOOK.md
@@ -32,6 +32,13 @@ For ENS, keep the same address and listener, set
 `adapter_direct_protocol=ens`, and expect
 `Transport: adapter-direct (tcp adapter-direct-ens://203.0.113.10:9999)`.
 
+An upgraded pre-selector configuration may still contain
+`proxy_profile=enh|ens` with an empty `proxy_endpoint`. Startup must log the
+legacy migration, emit the matching adapter-direct URI, report
+`Proxy profile: disabled`, and preserve `-proxy-listen`. Save the explicit
+`adapter_direct_protocol` and `proxy_profile=disabled` options afterward. If
+`proxy_endpoint` is populated, startup must reject the mixed configuration.
+
 ## Install and start add-on
 
 1) Add repository:

--- a/helianthus/CHANGELOG.md
+++ b/helianthus/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.6.49 (2026-08-17)
+
+- Add the typed `adapter_direct_protocol` selector with a compatible `enh`
+  default and exact ENH/ENS mapping to the gateway's existing adapter-direct
+  URI forms.
+- Keep `proxy_profile` scoped to external proxy input while preserving a
+  deterministic migration for pre-selector direct configurations and rejecting
+  every populated proxy endpoint in adapter-direct mode.
+- Preserve the gateway-integrated `-proxy-listen` argument for both physical
+  adapter protocols; the gateway binary and its transport implementation remain
+  unchanged from 0.6.48.
+
 ## 0.6.48 (2026-08-17)
 
 - Remove the Modbus-specific Bash process supervisor, FIFO redactors,

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -52,7 +52,7 @@ protocol-local; eBUS, eeBUS, HTTP, and MCP keep the normal gateway lifecycle.
 Upgrade startup removes the retired Modbus health record. Any failure before
 the final `exec` also removes the protected endpoint file.
 
-Release `0.6.48` packages the consolidated gateway with bounded FM5 startup
+Release `0.6.49` packages the consolidated gateway with bounded FM5 startup
 convergence, source-owned endpoint sanitization, and protocol-local Modbus
 startup failure. All
 eeBUS-specific credential provisioning remains removed, and the read-only

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -86,6 +86,13 @@ Keep `proxy_profile=disabled`: adapter-direct and an external proxy endpoint are
 mutually exclusive configurations. The gateway-integrated proxy listener is
 preserved for both adapter protocols.
 
+For upgrade compatibility only, the wrapper recognizes the exact old
+adapter-direct shape `proxy_profile=enh|ens` with an empty `proxy_endpoint`,
+migrates it to the matching adapter-direct protocol, and disables the effective
+proxy profile. Save `adapter_direct_protocol` explicitly and reset
+`proxy_profile=disabled` after upgrading. Adapter-direct plus a populated
+external `proxy_endpoint` is rejected.
+
 ## Debugging tools
 
 This add-on image includes `helianthus_vrc_explorer` at `/usr/bin/helianthus_vrc_explorer`.

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -86,10 +86,12 @@ Keep `proxy_profile=disabled`: adapter-direct and an external proxy endpoint are
 mutually exclusive configurations. The gateway-integrated proxy listener is
 preserved for both adapter protocols.
 
-For upgrade compatibility only, the wrapper recognizes the exact old
-adapter-direct shape `proxy_profile=enh|ens` with an empty `proxy_endpoint`,
-migrates it to the matching adapter-direct protocol, and disables the effective
-proxy profile. Save `adapter_direct_protocol` explicitly and reset
+For upgrade compatibility only, when persisted options do not yet contain
+`adapter_direct_protocol`, the wrapper recognizes the exact old adapter-direct
+shape `proxy_profile=enh|ens` with an empty `proxy_endpoint`, migrates it to the
+matching adapter-direct protocol, and disables the effective proxy profile.
+Once the typed key is persisted it remains authoritative even if the stale
+profile remains. Save `adapter_direct_protocol` explicitly and reset
 `proxy_profile=disabled` after upgrading. Adapter-direct plus a populated
 external `proxy_endpoint` is rejected.
 

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -21,7 +21,8 @@ Home Assistant add-on that runs the Helianthus eBUS gateway (GraphQL + MCP).
 Key options are exposed in `config.json`:
 
 - `adapter_direct_enabled`: connect through the gateway adapter-direct path
-- `adapter_direct_address`: physical adapter endpoint for adapter-direct mode (e.g. `enh://<host>:<port>`)
+- `adapter_direct_protocol`: explicit physical adapter protocol, `enh` or `ens` (default `enh`)
+- `adapter_direct_address`: physical adapter endpoint for adapter-direct mode (`<host>:<port>`)
 - `proxy_listen_addr`: gateway-embedded adaptermux proxy listener address (default `0.0.0.0:19001`)
 - `transport`: `enh`, `ens`, `udp-plain`, or `ebusd-tcp`
 - `network`: `tcp`, `udp`, or `unix`
@@ -78,8 +79,12 @@ Stable instance GUID persistence:
 - Removing `/data/instance_guid` or reinstalling without restoring `/data` creates a new Helianthus instance identity.
 
 For embedded adaptermux proxy mode, set `adapter_direct_enabled=true`,
-`adapter_direct_address=<adapter-endpoint>`, and `proxy_listen_addr=<listen-host:port>`.
-Leave `proxy_profile=disabled` unless intentionally connecting the gateway to an external proxy endpoint.
+`adapter_direct_protocol=enh|ens`, `adapter_direct_address=<adapter-endpoint>`,
+and `proxy_listen_addr=<listen-host:port>`. ENH emits
+`adapter-direct://HOST:PORT`; ENS emits `adapter-direct-ens://HOST:PORT`.
+Keep `proxy_profile=disabled`: adapter-direct and an external proxy endpoint are
+mutually exclusive configurations. The gateway-integrated proxy listener is
+preserved for both adapter protocols.
 
 ## Debugging tools
 

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.6.48",
+  "version": "0.6.49",
   "slug": "helianthus",
   "description": "Helianthus multi-runtime gateway (GraphQL + MCP)",
   "arch": [

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -20,6 +20,7 @@
   "image": "ghcr.io/project-helianthus/helianthus-ha-addon",
   "options": {
     "adapter_direct_enabled": true,
+    "adapter_direct_protocol": "enh",
     "adapter_direct_address": "",
     "proxy_listen_addr": "0.0.0.0:19001",
     "transport": "enh",
@@ -60,6 +61,7 @@
   },
   "schema": {
     "adapter_direct_enabled": "bool",
+    "adapter_direct_protocol": "list(enh|ens)",
     "adapter_direct_address": "str",
     "proxy_listen_addr": "str",
     "transport": "list(enh|ens|udp-plain|ebusd-tcp)",

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -426,18 +426,29 @@ case "${proxy_profile}" in
     ;;
   enh | ens)
     if bashio::var.true "${adapter_direct_enabled}"; then
-      bashio::exit.nok "adapter_direct_enabled=true requires proxy_profile=disabled"
-    fi
-    if [ -z "${proxy_endpoint_trimmed}" ]; then
-      bashio::exit.nok "proxy_endpoint is required when proxy_profile=${proxy_profile}"
-    fi
-    if [[ "${proxy_endpoint_trimmed}" == *"://"* ]]; then
-      effective_address="${proxy_endpoint_trimmed}"
+      # Compatibility migration for pre-selector installs. The old wrapper
+      # used proxy_profile as the accidental adapter-direct ENS/ENH selector;
+      # those configurations have no proxy endpoint. Consume that exact legacy
+      # shape, then disable the effective proxy profile so normal adapter-direct
+      # routing remains owned solely by adapter_direct_protocol.
+      if [ -n "${proxy_endpoint_trimmed}" ]; then
+        bashio::exit.nok "adapter_direct_enabled=true requires proxy_profile=disabled"
+      fi
+      bashio::log.warning "Migrating legacy adapter-direct proxy_profile=${proxy_profile} to adapter_direct_protocol=${proxy_profile}; save adapter_direct_protocol=${proxy_profile} and proxy_profile=disabled in add-on options"
+      adapter_direct_protocol="${proxy_profile}"
+      proxy_profile="disabled"
     else
-      effective_address="${proxy_profile}://${proxy_endpoint_trimmed}"
+      if [ -z "${proxy_endpoint_trimmed}" ]; then
+        bashio::exit.nok "proxy_endpoint is required when proxy_profile=${proxy_profile}"
+      fi
+      if [[ "${proxy_endpoint_trimmed}" == *"://"* ]]; then
+        effective_address="${proxy_endpoint_trimmed}"
+      else
+        effective_address="${proxy_profile}://${proxy_endpoint_trimmed}"
+      fi
+      effective_transport="${proxy_profile}"
+      effective_network="tcp"
     fi
-    effective_transport="${proxy_profile}"
-    effective_network="tcp"
     ;;
   *)
     bashio::exit.nok "proxy_profile must be one of: disabled, enh, ens"

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -28,6 +28,7 @@ read_timeout=$(bashio::config 'read_timeout')
 write_timeout=$(bashio::config 'write_timeout')
 dial_timeout=$(bashio::config 'dial_timeout')
 adapter_direct_enabled=$(bashio::config 'adapter_direct_enabled' 2>/dev/null || true)
+adapter_direct_protocol=$(bashio::config 'adapter_direct_protocol' 2>/dev/null || true)
 adapter_direct_address=$(bashio::config 'adapter_direct_address' 2>/dev/null || true)
 proxy_listen_addr=$(bashio::config 'proxy_listen_addr' 2>/dev/null || true)
 # F-1 defensive fallback (EBUSD-VERIFICATION-2026-05-10.md): HA Supervisor's
@@ -343,6 +344,14 @@ fi
 if [ -z "${adapter_direct_address}" ] || [ "${adapter_direct_address}" = "null" ]; then
   adapter_direct_address=""
 fi
+adapter_direct_protocol=$(printf '%s' "${adapter_direct_protocol}" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+if [ -z "${adapter_direct_protocol}" ] || [ "${adapter_direct_protocol}" = "null" ]; then
+  adapter_direct_protocol="enh"
+fi
+case "${adapter_direct_protocol}" in
+  enh | ens) ;;
+  *) bashio::exit.nok "adapter_direct_protocol must be one of: enh, ens" ;;
+esac
 if [ "${proxy_listen_addr}" = "null" ]; then
   proxy_listen_addr="0.0.0.0:19001"
 fi
@@ -416,7 +425,10 @@ case "${proxy_profile}" in
     proxy_profile="disabled"
     ;;
   enh | ens)
-    if [ -z "${proxy_endpoint_trimmed}" ] && ! bashio::var.true "${adapter_direct_enabled}"; then
+    if bashio::var.true "${adapter_direct_enabled}"; then
+      bashio::exit.nok "adapter_direct_enabled=true requires proxy_profile=disabled"
+    fi
+    if [ -z "${proxy_endpoint_trimmed}" ]; then
       bashio::exit.nok "proxy_endpoint is required when proxy_profile=${proxy_profile}"
     fi
     if [[ "${proxy_endpoint_trimmed}" == *"://"* ]]; then
@@ -443,16 +455,13 @@ fi
 # adapter-direct mode: override transport to adapter-direct:// URI
 if bashio::var.true "${adapter_direct_enabled}"; then
   # Strip whitespace, then strip any scheme prefix (ens://, enh://, adapter-direct://)
-  # so the user can paste any URI format and we normalize to plain host:port.
+  # for compatibility. The typed adapter_direct_protocol option remains the
+  # only authority for selecting ENH versus ENS.
   adapter_direct_address_trimmed=$(printf '%s' "${adapter_direct_address}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s|^[a-zA-Z][-a-zA-Z0-9]*://||')
   if [ -z "${adapter_direct_address_trimmed}" ]; then
     bashio::exit.nok "adapter_direct_address is required when adapter_direct_enabled=true"
   fi
-  if [ "${proxy_profile}" != "disabled" ]; then
-    bashio::log.warning "adapter_direct_enabled=true overrides proxy_profile=${proxy_profile}; adapter-direct takes precedence"
-  fi
-  # Use adapter-direct-ens:// if proxy_profile is ens, otherwise adapter-direct:// (ENH default)
-  if [ "${proxy_profile}" = "ens" ]; then
+  if [ "${adapter_direct_protocol}" = "ens" ]; then
     effective_address="adapter-direct-ens://${adapter_direct_address_trimmed}"
   else
     effective_address="adapter-direct://${adapter_direct_address_trimmed}"
@@ -544,7 +553,7 @@ bashio::log.info "Proxy profile: ${proxy_profile}"
 bashio::log.info "Proxy endpoint: ${proxy_endpoint_marker}"
 proxy_listen_args=()
 if bashio::var.true "${adapter_direct_enabled}"; then
-  bashio::log.info "Adapter-direct: enabled=${adapter_direct_enabled} address=${adapter_direct_address}"
+  bashio::log.info "Adapter-direct: enabled=${adapter_direct_enabled} protocol=${adapter_direct_protocol} address=${adapter_direct_address}"
   if [ -n "${proxy_listen_addr}" ]; then
     proxy_listen_args=(-proxy-listen "${proxy_listen_addr}")
     bashio::log.info "Proxy listener: ${proxy_listen_addr}"

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -419,6 +419,9 @@ effective_address="${address}"
 
 proxy_profile=$(printf '%s' "${proxy_profile}" | tr '[:upper:]' '[:lower:]')
 proxy_endpoint_trimmed=$(printf '%s' "${proxy_endpoint}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+if bashio::var.true "${adapter_direct_enabled}" && [ -n "${proxy_endpoint_trimmed}" ]; then
+  bashio::exit.nok "adapter_direct_enabled=true requires proxy_endpoint to be empty"
+fi
 
 case "${proxy_profile}" in
   "" | disabled)
@@ -431,9 +434,6 @@ case "${proxy_profile}" in
       # those configurations have no proxy endpoint. Consume that exact legacy
       # shape, then disable the effective proxy profile so normal adapter-direct
       # routing remains owned solely by adapter_direct_protocol.
-      if [ -n "${proxy_endpoint_trimmed}" ]; then
-        bashio::exit.nok "adapter_direct_enabled=true requires proxy_profile=disabled"
-      fi
       bashio::log.warning "Migrating legacy adapter-direct proxy_profile=${proxy_profile} to adapter_direct_protocol=${proxy_profile}; save adapter_direct_protocol=${proxy_profile} and proxy_profile=disabled in add-on options"
       adapter_direct_protocol="${proxy_profile}"
       proxy_profile="disabled"

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -31,6 +31,13 @@ adapter_direct_enabled=$(bashio::config 'adapter_direct_enabled' 2>/dev/null || 
 adapter_direct_protocol=$(bashio::config 'adapter_direct_protocol' 2>/dev/null || true)
 adapter_direct_address=$(bashio::config 'adapter_direct_address' 2>/dev/null || true)
 proxy_listen_addr=$(bashio::config 'proxy_listen_addr' 2>/dev/null || true)
+addon_options_path="${HELIANTHUS_OPTIONS_PATH:-/data/options.json}"
+adapter_direct_protocol_persisted=false
+if [ -f "${addon_options_path}" ] && command -v jq >/dev/null 2>&1 && \
+  jq -e 'type == "object" and has("adapter_direct_protocol") and .adapter_direct_protocol != null' \
+    "${addon_options_path}" >/dev/null 2>&1; then
+  adapter_direct_protocol_persisted=true
+fi
 # F-1 defensive fallback (EBUSD-VERIFICATION-2026-05-10.md): HA Supervisor's
 # /addons/self/options/config endpoint has been observed silently returning
 # empty for proxy_listen_addr despite the value being correctly stored in
@@ -431,11 +438,15 @@ case "${proxy_profile}" in
     if bashio::var.true "${adapter_direct_enabled}"; then
       # Compatibility migration for pre-selector installs. The old wrapper
       # used proxy_profile as the accidental adapter-direct ENS/ENH selector;
-      # those configurations have no proxy endpoint. Consume that exact legacy
-      # shape, then disable the effective proxy profile so normal adapter-direct
-      # routing remains owned solely by adapter_direct_protocol.
-      bashio::log.warning "Migrating legacy adapter-direct proxy_profile=${proxy_profile} to adapter_direct_protocol=${proxy_profile}; save adapter_direct_protocol=${proxy_profile} and proxy_profile=disabled in add-on options"
-      adapter_direct_protocol="${proxy_profile}"
+      # those configurations have no persisted selector or proxy endpoint.
+      # Once the typed key is persisted it remains authoritative, even while a
+      # stale legacy profile still exists.
+      if [ "${adapter_direct_protocol_persisted}" = true ]; then
+        bashio::log.warning "Ignoring stale adapter-direct proxy_profile=${proxy_profile}; adapter_direct_protocol=${adapter_direct_protocol} is explicitly persisted; save proxy_profile=disabled in add-on options"
+      else
+        bashio::log.warning "Migrating legacy adapter-direct proxy_profile=${proxy_profile} to adapter_direct_protocol=${proxy_profile}; save adapter_direct_protocol=${proxy_profile} and proxy_profile=disabled in add-on options"
+        adapter_direct_protocol="${proxy_profile}"
+      fi
       proxy_profile="disabled"
     else
       if [ -z "${proxy_endpoint_trimmed}" ]; then

--- a/scripts/check_eebus_wrapper.py
+++ b/scripts/check_eebus_wrapper.py
@@ -15,7 +15,7 @@ PARITY = ROOT / "scripts/fixtures/gateway_parity_artifact_pass.json"
 RUN = ROOT / "helianthus/rootfs/etc/services.d/helianthus-gateway/run"
 HELPER = ROOT / "helianthus/rootfs/usr/share/helianthus/eebus_admin_credentials.py"
 
-RELEASE = "0.6.48"
+RELEASE = "0.6.49"
 GATEWAY = "7f1cbea90e0b189486febc656632e9e7430c8500"
 REMOVED_OPTIONS = (
     "eebus_admin_enabled",
@@ -40,7 +40,7 @@ def main() -> int:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     run = RUN.read_text(encoding="utf-8")
 
-    assert config["version"] == RELEASE, "config.json must be the 0.6.48 release authority"
+    assert config["version"] == RELEASE, "config.json must be the 0.6.49 release authority"
     assert f"ARG EBUSGATEWAY_VERSION={GATEWAY}" in dockerfile, "Dockerfile primary gateway pin drifted"
     assert f"EBUSGATEWAY_VERSION={GATEWAY}" in workflow, "workflow primary gateway pin drifted"
     for key in ("source_ref", "tested_ref"):

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -341,7 +341,7 @@ def _check_adapter_direct_protocol_contract() -> None:
         )
         _assert(conflict_argv == [], "adapter-direct/proxy conflict must fail before gateway exec")
         _assert(
-            "adapter_direct_enabled=true requires proxy_profile=disabled" in conflict_stderr,
+            "adapter_direct_enabled=true requires proxy_endpoint to be empty" in conflict_stderr,
             "adapter-direct/proxy conflict must explain the mutually exclusive configuration",
         )
 

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -297,6 +297,39 @@ def _check_adapter_direct_protocol_contract() -> None:
             f"adapter_direct_protocol={protocol!r} dropped the integrated proxy listener",
         )
 
+    # Upgrade compatibility: before adapter_direct_protocol existed, direct
+    # installs used proxy_profile as the accidental ENS/ENH selector and left
+    # proxy_endpoint empty. Migrate that exact legacy shape deterministically.
+    for legacy_profile, expected_address in (
+        ("enh", "adapter-direct://203.0.113.10:9999"),
+        ("ens", "adapter-direct-ens://203.0.113.10:9999"),
+    ):
+        argv, logs, _state_exists, _state_content, _stderr = _run_wrapper_case(
+            source_addr="auto",
+            gateway_mode="new",
+            adapter_direct_protocol="enh",
+            proxy_profile=legacy_profile,
+            proxy_endpoint="",
+        )
+        _assert(
+            _argv_value(argv, "-address") == expected_address,
+            f"legacy proxy_profile={legacy_profile} was not migrated to adapter-direct",
+        )
+        _assert(
+            _argv_value(argv, "-proxy-listen") == "0.0.0.0:19001",
+            f"legacy proxy_profile={legacy_profile} migration dropped the integrated proxy listener",
+        )
+        _assert(
+            f"Migrating legacy adapter-direct proxy_profile={legacy_profile}" in logs,
+            f"legacy proxy_profile={legacy_profile} migration must be visible in logs",
+        )
+        _assert(
+            "Proxy profile: disabled" in logs,
+            f"legacy proxy_profile={legacy_profile} must not remain an active proxy profile",
+        )
+
+    # A populated proxy endpoint is a genuine external-proxy configuration,
+    # not the old adapter-direct selector shape, so it remains invalid here.
     for proxy_profile in ("enh", "ens"):
         conflict_argv, _logs, _state_exists, _state_content, conflict_stderr = _run_wrapper_case(
             source_addr="auto",

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -330,7 +330,7 @@ def _check_adapter_direct_protocol_contract() -> None:
 
     # A populated proxy endpoint is a genuine external-proxy configuration,
     # not the old adapter-direct selector shape, so it remains invalid here.
-    for proxy_profile in ("enh", "ens"):
+    for proxy_profile in ("disabled", "enh", "ens"):
         conflict_argv, _logs, _state_exists, _state_content, conflict_stderr = _run_wrapper_case(
             source_addr="auto",
             gateway_mode="new",

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -265,9 +265,9 @@ def _check_adapter_direct_protocol_contract() -> None:
         ("enh", "203.0.113.10:9999", "disabled", "", "adapter-direct://203.0.113.10:9999"),
         ("ens", "203.0.113.10:9999", "disabled", "", "adapter-direct-ens://203.0.113.10:9999"),
         # The explicit adapter selector is authoritative even when a legacy
-        # address prefix or proxy profile suggests the opposite protocol.
-        ("enh", "ens://203.0.113.10:9999", "ens", "proxy.example.invalid:9999", "adapter-direct://203.0.113.10:9999"),
-        ("ens", "enh://203.0.113.10:9999", "enh", "proxy.example.invalid:9999", "adapter-direct-ens://203.0.113.10:9999"),
+        # address prefix suggests the opposite protocol.
+        ("enh", "ens://203.0.113.10:9999", "disabled", "", "adapter-direct://203.0.113.10:9999"),
+        ("ens", "enh://203.0.113.10:9999", "disabled", "", "adapter-direct-ens://203.0.113.10:9999"),
         # Missing upgrade-era input has the deterministic compatibility default.
         ("", "203.0.113.10:9999", "disabled", "", "adapter-direct://203.0.113.10:9999"),
     )
@@ -295,6 +295,21 @@ def _check_adapter_direct_protocol_contract() -> None:
         _assert(
             _argv_value(argv, "-proxy-listen") == "0.0.0.0:19001",
             f"adapter_direct_protocol={protocol!r} dropped the integrated proxy listener",
+        )
+
+    for proxy_profile in ("enh", "ens"):
+        conflict_argv, _logs, _state_exists, _state_content, conflict_stderr = _run_wrapper_case(
+            source_addr="auto",
+            gateway_mode="new",
+            adapter_direct_protocol="enh",
+            proxy_profile=proxy_profile,
+            proxy_endpoint="proxy.example.invalid:9999",
+            expect_success=False,
+        )
+        _assert(conflict_argv == [], "adapter-direct/proxy conflict must fail before gateway exec")
+        _assert(
+            "adapter_direct_enabled=true requires proxy_profile=disabled" in conflict_stderr,
+            "adapter-direct/proxy conflict must explain the mutually exclusive configuration",
         )
 
     invalid_argv, _logs, _state_exists, _state_content, invalid_stderr = _run_wrapper_case(

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -149,6 +149,7 @@ def _run_wrapper_case(
     transport: str = "enh",
     adapter_direct_enabled: bool = True,
     adapter_direct_protocol: str = "enh",
+    adapter_direct_protocol_persisted: bool = True,
     adapter_direct_address: str = "203.0.113.10:9999",
     proxy_profile: str = "disabled",
     proxy_endpoint: str = "",
@@ -190,6 +191,11 @@ def _run_wrapper_case(
         instance_guid_file = tmp / "instance_guid"
         # Legacy file deliberately absent; runtime_state.json is the source.
         legacy_marker_file = tmp / "migration_marker"
+        addon_options_file = tmp / "addon-options.json"
+        addon_options: dict[str, object] = {}
+        if adapter_direct_protocol_persisted:
+            addon_options["adapter_direct_protocol"] = adapter_direct_protocol
+        addon_options_file.write_text(json.dumps(addon_options) + "\n", encoding="utf-8")
         _write_test_wrapper(wrapper)
         _write_gateway_stub(gateway, gateway_mode)
 
@@ -220,6 +226,7 @@ def _run_wrapper_case(
                 "HELIANTHUS_MODBUS_RUNTIME_GUARD": str(MODBUS_RUNTIME_GUARD),
                 "HELIANTHUS_MODBUS_OPTIONS_PATH": str(tmp / "missing-options.json"),
                 "HELIANTHUS_MODBUS_ENDPOINT_FILE": str(tmp / "modbus-endpoint"),
+                "HELIANTHUS_OPTIONS_PATH": str(addon_options_file),
             },
         )
 
@@ -308,6 +315,7 @@ def _check_adapter_direct_protocol_contract() -> None:
             source_addr="auto",
             gateway_mode="new",
             adapter_direct_protocol="enh",
+            adapter_direct_protocol_persisted=False,
             proxy_profile=legacy_profile,
             proxy_endpoint="",
         )
@@ -326,6 +334,29 @@ def _check_adapter_direct_protocol_contract() -> None:
         _assert(
             "Proxy profile: disabled" in logs,
             f"legacy proxy_profile={legacy_profile} must not remain an active proxy profile",
+        )
+
+    # Once the new key exists in persisted options it is authoritative, even
+    # if a stale empty-endpoint legacy profile has not yet been cleared.
+    for protocol, stale_profile, expected_address in (
+        ("enh", "ens", "adapter-direct://203.0.113.10:9999"),
+        ("ens", "enh", "adapter-direct-ens://203.0.113.10:9999"),
+    ):
+        argv, logs, _state_exists, _state_content, _stderr = _run_wrapper_case(
+            source_addr="auto",
+            gateway_mode="new",
+            adapter_direct_protocol=protocol,
+            adapter_direct_protocol_persisted=True,
+            proxy_profile=stale_profile,
+            proxy_endpoint="",
+        )
+        _assert(
+            _argv_value(argv, "-address") == expected_address,
+            f"explicit adapter_direct_protocol={protocol} was overridden by stale proxy_profile={stale_profile}",
+        )
+        _assert(
+            "Proxy profile: disabled" in logs,
+            f"stale proxy_profile={stale_profile} must be normalized after explicit selection",
         )
 
     # A populated proxy endpoint is a genuine external-proxy configuration,

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -13,6 +13,7 @@ import tempfile
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 RUN_SCRIPT = REPO_ROOT / "helianthus/rootfs/etc/services.d/helianthus-gateway/run"
+CONFIG_PATH = REPO_ROOT / "helianthus/config.json"
 RUNTIME_STATE_WRAPPER = REPO_ROOT / "helianthus/rootfs/usr/share/helianthus/check_runtime_state_wrapper.py"
 MODBUS_RUNTIME_GUARD = REPO_ROOT / "helianthus/rootfs/usr/share/helianthus/modbus_runtime_guard.py"
 DOCKERFILE = REPO_ROOT / "helianthus/Dockerfile"
@@ -48,6 +49,7 @@ bashio::config() {
     dial_timeout) printf '%s\n' "${TEST_DIAL_TIMEOUT:-5s}" ;;
     adapter_direct_enabled) printf '%s\n' "${TEST_ADAPTER_DIRECT_ENABLED:-false}" ;;
     adapter_direct_address) printf '%s\n' "${TEST_ADAPTER_DIRECT_ADDRESS:-}" ;;
+    adapter_direct_protocol) printf '%s\n' "${TEST_ADAPTER_DIRECT_PROTOCOL:-enh}" ;;
     proxy_listen_addr) printf '%s\n' "${TEST_PROXY_LISTEN_ADDR:-0.0.0.0:19001}" ;;
     observe_first_enabled) printf '%s\n' "${TEST_OBSERVE_FIRST_ENABLED:-true}" ;;
     passive_state_direct_apply) printf '%s\n' "${TEST_PASSIVE_STATE_DIRECT_APPLY:-true}" ;;
@@ -146,6 +148,11 @@ def _run_wrapper_case(
     existing_state: str | None = None,
     transport: str = "enh",
     adapter_direct_enabled: bool = True,
+    adapter_direct_protocol: str = "enh",
+    adapter_direct_address: str = "203.0.113.10:9999",
+    proxy_profile: str = "disabled",
+    proxy_endpoint: str = "",
+    proxy_listen_addr: str = "0.0.0.0:19001",
     expect_success: bool = True,
 ) -> tuple[list[str], str, bool, str, str]:
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -198,7 +205,11 @@ def _run_wrapper_case(
                 "TEST_LEGACY_SOURCE_ADDR_STATE_FILE": str(state_file),
                 "TEST_TRANSPORT": transport,
                 "TEST_ADAPTER_DIRECT_ENABLED": "true" if adapter_direct_enabled else "false",
-                "TEST_ADAPTER_DIRECT_ADDRESS": "203.0.113.10:9999",
+                "TEST_ADAPTER_DIRECT_PROTOCOL": adapter_direct_protocol,
+                "TEST_ADAPTER_DIRECT_ADDRESS": adapter_direct_address,
+                "TEST_PROXY_PROFILE": proxy_profile,
+                "TEST_PROXY_ENDPOINT": proxy_endpoint,
+                "TEST_PROXY_LISTEN_ADDR": proxy_listen_addr,
                 # M6 wrapper integration: redirect bash + Python sides at the
                 # in-repo wrapper script and the temp-sandboxed runtime-state
                 # paths so the test runs on a host without /data/ (CI).
@@ -230,6 +241,73 @@ def _run_wrapper_case(
         state_exists = state_file.exists()
         state_content = state_file.read_text(encoding="utf-8") if state_exists else ""
         return argv, logs, state_exists, state_content, result.stderr
+
+
+def _argv_value(argv: list[str], flag: str) -> str:
+    _assert(flag in argv, f"gateway argv is missing {flag}: {argv}")
+    index = argv.index(flag)
+    _assert(index + 1 < len(argv), f"gateway argv has no value after {flag}: {argv}")
+    return argv[index + 1]
+
+
+def _check_adapter_direct_protocol_contract() -> None:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+    _assert(
+        config["options"].get("adapter_direct_protocol") == "enh",
+        "adapter_direct_protocol must default to enh",
+    )
+    _assert(
+        config["schema"].get("adapter_direct_protocol") == "list(enh|ens)",
+        "adapter_direct_protocol must be typed as list(enh|ens)",
+    )
+
+    cases = (
+        ("enh", "203.0.113.10:9999", "disabled", "", "adapter-direct://203.0.113.10:9999"),
+        ("ens", "203.0.113.10:9999", "disabled", "", "adapter-direct-ens://203.0.113.10:9999"),
+        # The explicit adapter selector is authoritative even when a legacy
+        # address prefix or proxy profile suggests the opposite protocol.
+        ("enh", "ens://203.0.113.10:9999", "ens", "proxy.example.invalid:9999", "adapter-direct://203.0.113.10:9999"),
+        ("ens", "enh://203.0.113.10:9999", "enh", "proxy.example.invalid:9999", "adapter-direct-ens://203.0.113.10:9999"),
+        # Missing upgrade-era input has the deterministic compatibility default.
+        ("", "203.0.113.10:9999", "disabled", "", "adapter-direct://203.0.113.10:9999"),
+    )
+    for protocol, address, proxy_profile, proxy_endpoint, expected_address in cases:
+        argv, _logs, _state_exists, _state_content, _stderr = _run_wrapper_case(
+            source_addr="auto",
+            gateway_mode="new",
+            adapter_direct_protocol=protocol,
+            adapter_direct_address=address,
+            proxy_profile=proxy_profile,
+            proxy_endpoint=proxy_endpoint,
+        )
+        _assert(
+            _argv_value(argv, "-transport") == "adapter-direct",
+            f"adapter_direct_protocol={protocol!r} changed the gateway transport",
+        )
+        _assert(
+            _argv_value(argv, "-network") == "tcp",
+            f"adapter_direct_protocol={protocol!r} did not force TCP",
+        )
+        _assert(
+            _argv_value(argv, "-address") == expected_address,
+            f"adapter_direct_protocol={protocol!r} produced the wrong gateway address",
+        )
+        _assert(
+            _argv_value(argv, "-proxy-listen") == "0.0.0.0:19001",
+            f"adapter_direct_protocol={protocol!r} dropped the integrated proxy listener",
+        )
+
+    invalid_argv, _logs, _state_exists, _state_content, invalid_stderr = _run_wrapper_case(
+        source_addr="auto",
+        gateway_mode="new",
+        adapter_direct_protocol="auto",
+        expect_success=False,
+    )
+    _assert(invalid_argv == [], "invalid adapter_direct_protocol must fail before gateway exec")
+    _assert(
+        "adapter_direct_protocol must be one of: enh, ens" in invalid_stderr,
+        "invalid adapter_direct_protocol failure must explain the accepted values",
+    )
 
 
 def _check_static_run_script() -> None:
@@ -443,6 +521,7 @@ def _check_runtime_cases() -> None:
 
 def main() -> int:
     try:
+        _check_adapter_direct_protocol_contract()
         _check_static_run_script()
         _check_docs()
         _check_runtime_cases()

--- a/tests/test_eebus_admin_wrapper.py
+++ b/tests/test_eebus_admin_wrapper.py
@@ -15,7 +15,7 @@ PARITY = ROOT / "scripts/fixtures/gateway_parity_artifact_pass.json"
 RUN = ROOT / "helianthus/rootfs/etc/services.d/helianthus-gateway/run"
 HELPER = ROOT / "helianthus/rootfs/usr/share/helianthus/eebus_admin_credentials.py"
 
-RELEASE = "0.6.48"
+RELEASE = "0.6.49"
 GATEWAY = "7f1cbea90e0b189486febc656632e9e7430c8500"
 REMOVED_OPTIONS = (
     "eebus_admin_enabled",
@@ -33,7 +33,7 @@ REMOVED_WRAPPER_TERMS = (
 )
 
 
-def test_release_pin_is_0648_and_gateway_provenance_is_exact() -> None:
+def test_release_pin_is_0649_and_gateway_provenance_is_exact() -> None:
     config = json.loads(CONFIG.read_text(encoding="utf-8"))
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     workflow = WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## What

Adds a typed `adapter_direct_protocol` option that maps ENH and ENS explicitly to the two adapter-direct URI forms already supported by the gateway, released as add-on `0.6.49`.

## Behavior

- default `enh` -> `adapter-direct://HOST:PORT`
- `ens` -> `adapter-direct-ens://HOST:PORT`
- a persisted typed selector is authoritative and address schemes are syntax-only
- pre-selector persisted state may migrate an empty-endpoint legacy `proxy_profile=enh|ens`, then normalizes the effective profile to disabled
- any populated `proxy_endpoint` conflicts with adapter-direct and fails before exec
- `proxy_listen_addr` and emitted `-proxy-listen` remain preserved for both protocols

## TDD and validation

- RED commits: `f3014cf`, `61ebc88`, `fd1d515`, `6932539`, `f693609`, `d5e7a16`
- exact final HEAD: `670d34b2344c1625cfeeebcb97c3481b537d09d3`
- `python3 scripts/check_source_addr_wrapper.py`: PASS
- focused single-exec/Modbus/eeBUS: 29 passed
- `./scripts/ci_local.sh`: PASS, including 4 eeBUS, 25 Modbus lifecycle, and 3 parity tests
- version/config/current docs authorities aligned at `0.6.49`; 0.6.48 changelog history unchanged
- T01..T88: NOT_APPLICABLE by independent second opinion; packaging/schema/argv only, with no gateway binary, parser, framing, timing, retry, or transport harness change
- no deploy, restart, or live mutation

## Documentation

- Primary companion docs: Project-Helianthus/helianthus-docs-ebus#456 / merged PR #457 (`a9f9e28fafbcdf07df1c9ef5c05e2548e4140291`)
- Legacy migration clarification: Project-Helianthus/helianthus-docs-ebus#458 / merged PR #459 (`80830d78fa22ce666e91e28a3961d5c72e107a77`)

Closes #208