### PR TITLE
Fix legacy option saves and Modbus endpoint field

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,13 @@ ha addons repo add https://github.com/Project-Helianthus/helianthus-ha-addon
 ```
 
 Then install **Helianthus** from the Add-on Store and open add-on configuration.
-Release `0.6.49` packages the consolidated gateway with bounded FM5 startup
-convergence, source-owned endpoint sanitization, and protocol-local Modbus
-startup failure. Enabled and disabled Modbus configurations use the same direct
-gateway `exec` lifecycle; Modbus remains disabled by default.
+Release `0.6.50` packages the same consolidated gateway as 0.6.49 and fixes
+Supervisor option compatibility: pre-selector configurations remain saveable,
+and the non-secret Modbus TCP endpoint is displayed as text. The gateway keeps
+bounded FM5 startup convergence, source-owned endpoint sanitization, and
+protocol-local Modbus startup failure. Enabled and disabled Modbus
+configurations use the same direct gateway `exec` lifecycle; Modbus remains
+disabled by default.
 
 ### 3) Baseline add-on configuration example (local ebusd-tcp)
 
@@ -114,13 +117,16 @@ adapter-direct mode; `proxy_profile` is reserved for an external proxy endpoint.
 The integrated proxy listener remains available through `proxy_listen_addr` for
 both adapter protocols.
 
-Upgrade compatibility is deterministic: when persisted options do not yet
+Upgrade compatibility is deterministic: `adapter_direct_protocol` is optional
+at the Supervisor schema boundary so persisted options created before 0.6.49
+remain saveable. When persisted options do not yet
 contain `adapter_direct_protocol`, a pre-selector adapter-direct configuration
 with `proxy_profile=enh|ens` and an empty `proxy_endpoint` is migrated at
 startup to the matching adapter-direct protocol, then treated as
 `proxy_profile=disabled`. Once the typed key is persisted, it is authoritative
 even if a stale empty-endpoint profile remains. Save the explicit
-`adapter_direct_protocol` and `proxy_profile=disabled` values after upgrading.
+`adapter_direct_protocol` and `proxy_profile=disabled` values when selecting a
+protocol explicitly.
 A populated `proxy_endpoint` is a real external-proxy configuration and remains
 invalid with adapter-direct.
 

--- a/SMOKE_RUNBOOK.md
+++ b/SMOKE_RUNBOOK.md
@@ -51,7 +51,7 @@ ha addons repo add https://github.com/Project-Helianthus/helianthus-ha-addon
 
 2) Install and start the `helianthus` add-on from Home Assistant Add-on Store.
 
-For release `0.6.49`, do not supply any eeBUS-specific credential options:
+For release `0.6.50`, do not supply any eeBUS-specific credential options:
 they remain removed. The consolidated runtime includes bounded FM5 startup
 convergence and source-owned endpoint sanitization. Modbus remains opt-in and
 uses the same direct gateway process lifecycle as the disabled configuration.

--- a/helianthus/CHANGELOG.md
+++ b/helianthus/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 0.6.50 (2026-08-17)
+
+- Keep `adapter_direct_protocol` truly optional in the Supervisor schema so
+  persisted configurations created before 0.6.49 can still be edited and
+  saved. The existing wrapper fallback remains authoritative when the key is
+  absent, while explicit `enh` and `ens` values remain supported.
+- Render `modbus_tcp_endpoint` as ordinary text routing configuration instead
+  of a password. Runtime validation still rejects embedded credentials and
+  continues to redact endpoint values from errors and logs.
+- Retain the exact 0.6.49 gateway pin and runtime behavior; this release changes
+  only add-on option schema, documentation, and regression coverage.
+
 ## 0.6.49 (2026-08-17)
 
 - Add the typed `adapter_direct_protocol` selector with a compatible `enh`

--- a/helianthus/README.md
+++ b/helianthus/README.md
@@ -40,7 +40,7 @@ Key options are exposed in `config.json`:
 - `eebus_enabled`: enable raw eeBUS runtime; pairing remains closed by default
 - `eebus_listen_port`, `eebus_interface`, `eebus_subnets`, `eebus_discovery_enabled`, and `eebus_remote_ski_allowlist`: raw eeBUS runtime network controls
 - `modbus_tcp_enabled`: opt in to the read-only Modbus TCP sidecar (default `false`)
-- `modbus_tcp_endpoint`: one `tcp://host:port` endpoint; Supervisor treats it as a password field and embedded credentials are rejected
+- `modbus_tcp_endpoint`: one visible `tcp://host:port` routing endpoint; embedded credentials are rejected
 - `modbus_tcp_dial_timeout`: bounded `ms` or `s` dial timeout from 100 ms through 30 s
 
 The add-on validates the closed option bundle, materializes the admitted
@@ -52,10 +52,11 @@ protocol-local; eBUS, eeBUS, HTTP, and MCP keep the normal gateway lifecycle.
 Upgrade startup removes the retired Modbus health record. Any failure before
 the final `exec` also removes the protected endpoint file.
 
-Release `0.6.49` packages the consolidated gateway with bounded FM5 startup
-convergence, source-owned endpoint sanitization, and protocol-local Modbus
-startup failure. All
-eeBUS-specific credential provisioning remains removed, and the read-only
+Release `0.6.50` packages the same consolidated gateway as 0.6.49 with an
+upgrade-safe optional adapter protocol selector and a visible, non-secret
+Modbus endpoint field. It retains bounded FM5 startup convergence,
+source-owned endpoint sanitization, and protocol-local Modbus startup failure.
+All eeBUS-specific credential provisioning remains removed, and the read-only
 Modbus runtime remains disabled unless explicitly enabled.
 
 For ebusd TCP mode, use `transport=ebusd-tcp`, `network=tcp`, and set `address=<ebusd-host>:<ebusd-port>`.

--- a/helianthus/config.json
+++ b/helianthus/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Helianthus",
-  "version": "0.6.49",
+  "version": "0.6.50",
   "slug": "helianthus",
   "description": "Helianthus multi-runtime gateway (GraphQL + MCP)",
   "arch": [
@@ -20,7 +20,6 @@
   "image": "ghcr.io/project-helianthus/helianthus-ha-addon",
   "options": {
     "adapter_direct_enabled": true,
-    "adapter_direct_protocol": "enh",
     "adapter_direct_address": "",
     "proxy_listen_addr": "0.0.0.0:19001",
     "transport": "enh",
@@ -61,7 +60,7 @@
   },
   "schema": {
     "adapter_direct_enabled": "bool",
-    "adapter_direct_protocol": "list(enh|ens)",
+    "adapter_direct_protocol": "list(enh|ens)?",
     "adapter_direct_address": "str",
     "proxy_listen_addr": "str",
     "transport": "list(enh|ens|udp-plain|ebusd-tcp)",
@@ -97,7 +96,7 @@
     "eebus_discovery_enabled": "bool",
     "eebus_remote_ski_allowlist": "str",
     "modbus_tcp_enabled": "bool",
-    "modbus_tcp_endpoint": "password",
+    "modbus_tcp_endpoint": "str",
     "modbus_tcp_dial_timeout": "str"
   }
 }

--- a/scripts/check_eebus_wrapper.py
+++ b/scripts/check_eebus_wrapper.py
@@ -15,7 +15,7 @@ PARITY = ROOT / "scripts/fixtures/gateway_parity_artifact_pass.json"
 RUN = ROOT / "helianthus/rootfs/etc/services.d/helianthus-gateway/run"
 HELPER = ROOT / "helianthus/rootfs/usr/share/helianthus/eebus_admin_credentials.py"
 
-RELEASE = "0.6.49"
+RELEASE = "0.6.50"
 GATEWAY = "7f1cbea90e0b189486febc656632e9e7430c8500"
 REMOVED_OPTIONS = (
     "eebus_admin_enabled",
@@ -40,7 +40,7 @@ def main() -> int:
     workflow = WORKFLOW.read_text(encoding="utf-8")
     run = RUN.read_text(encoding="utf-8")
 
-    assert config["version"] == RELEASE, "config.json must be the 0.6.49 release authority"
+    assert config["version"] == RELEASE, "config.json must be the 0.6.50 release authority"
     assert f"ARG EBUSGATEWAY_VERSION={GATEWAY}" in dockerfile, "Dockerfile primary gateway pin drifted"
     assert f"EBUSGATEWAY_VERSION={GATEWAY}" in workflow, "workflow primary gateway pin drifted"
     for key in ("source_ref", "tested_ref"):

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -260,12 +260,12 @@ def _argv_value(argv: list[str], flag: str) -> str:
 def _check_adapter_direct_protocol_contract() -> None:
     config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
     _assert(
-        config["options"].get("adapter_direct_protocol") == "enh",
-        "adapter_direct_protocol must default to enh",
+        "adapter_direct_protocol" not in config["options"],
+        "adapter_direct_protocol must remain absent from defaults for upgrade compatibility",
     )
     _assert(
-        config["schema"].get("adapter_direct_protocol") == "list(enh|ens)",
-        "adapter_direct_protocol must be typed as list(enh|ens)",
+        config["schema"].get("adapter_direct_protocol") == "list(enh|ens)?",
+        "adapter_direct_protocol must be typed as optional list(enh|ens)",
     )
 
     cases = (

--- a/tests/test_eebus_admin_wrapper.py
+++ b/tests/test_eebus_admin_wrapper.py
@@ -15,7 +15,7 @@ PARITY = ROOT / "scripts/fixtures/gateway_parity_artifact_pass.json"
 RUN = ROOT / "helianthus/rootfs/etc/services.d/helianthus-gateway/run"
 HELPER = ROOT / "helianthus/rootfs/usr/share/helianthus/eebus_admin_credentials.py"
 
-RELEASE = "0.6.49"
+RELEASE = "0.6.50"
 GATEWAY = "7f1cbea90e0b189486febc656632e9e7430c8500"
 REMOVED_OPTIONS = (
     "eebus_admin_enabled",
@@ -33,7 +33,7 @@ REMOVED_WRAPPER_TERMS = (
 )
 
 
-def test_release_pin_is_0649_and_gateway_provenance_is_exact() -> None:
+def test_release_pin_is_0650_and_gateway_provenance_is_exact() -> None:
     config = json.loads(CONFIG.read_text(encoding="utf-8"))
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
     workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/tests/test_modbus_runtime_guard.py
+++ b/tests/test_modbus_runtime_guard.py
@@ -172,7 +172,7 @@ def test_image_and_wrapper_use_only_current_gateway_and_one_exec() -> None:
     assert "gateway-fallback" not in dockerfile
     assert config["options"]["modbus_tcp_enabled"] is False
     assert config["options"]["modbus_tcp_endpoint"] == ""
-    assert config["schema"]["modbus_tcp_endpoint"] == "password"
+    assert config["schema"]["modbus_tcp_endpoint"] == "str"
     assert "-modbus-tcp-enabled=true" in run
     assert '-modbus-tcp-endpoint-file "${modbus_endpoint_file}"' in run
     assert run.count('exec "${gateway_bin}" "${gateway_args[@]}"') == 1

--- a/tests/test_modbus_runtime_guard.py
+++ b/tests/test_modbus_runtime_guard.py
@@ -180,3 +180,16 @@ def test_image_and_wrapper_use_only_current_gateway_and_one_exec() -> None:
     assert "modbus_child_pid" not in run
     assert "modbus_write_health" not in run
     assert "probe-readiness" not in run
+
+
+def test_supervisor_schema_accepts_legacy_options_and_shows_modbus_endpoint() -> None:
+    config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+    # Supervisor treats every schema entry with a default in options as
+    # required. Upgraded pre-selector configurations must remain saveable.
+    assert "adapter_direct_protocol" not in config["options"]
+    assert config["schema"]["adapter_direct_protocol"] == "list(enh|ens)?"
+
+    # A Modbus endpoint is routing configuration, not a credential. Runtime
+    # validation separately rejects userinfo and keeps error output redacted.
+    assert config["schema"]["modbus_tcp_endpoint"] == "str"


### PR DESCRIPTION
Closes #210

## Summary
- make `adapter_direct_protocol` genuinely optional at the Supervisor schema boundary so pre-0.6.49 persisted options remain saveable
- keep the existing wrapper fallback/migration and explicit ENH/ENS behavior unchanged
- render `modbus_tcp_endpoint` as ordinary text while retaining runtime credential rejection and log/error redaction
- publish as 0.6.50 so immutable 0.6.49 tags are not overwritten

## TDD
- RED: `0ee44498c1c0e75450c151c19b1018da8f5aa8db`
- GREEN: focused Modbus 18/18, wrapper selector PASS, eeBUS wrapper PASS, release contracts 4/4
- Full local CI: PASS; Modbus group 26/26 plus all repository gates

## Gates
- Docs gate: N/A, packaging/UI schema correction
- T01..T88: N/A, no transport or gateway code
- Live deploy: separate operator-confirmed action after publication