### PR TITLE
Fix rollout rollback predecessor for add-on 0.6.56

### DIFF
--- a/scripts/check_fronius_ha_rollout.py
+++ b/scripts/check_fronius_ha_rollout.py
@@ -219,7 +219,7 @@ def validate(
             or type(rollback["backup_required"]) is not bool
             or rollback
             != {
-                "prior_version": "0.6.53",
+                "prior_version": "0.6.55",
                 "schema_compatible": True,
                 "backup_required": True,
             }

--- a/scripts/fixtures/fronius_ha_rollout_contract_pass.json
+++ b/scripts/fixtures/fronius_ha_rollout_contract_pass.json
@@ -33,7 +33,7 @@
     "response_max_bytes": 1048576
   },
   "rollback": {
-    "prior_version": "0.6.53",
+    "prior_version": "0.6.55",
     "schema_compatible": true,
     "backup_required": true
   },

--- a/tests/test_fronius_ha_rollout.py
+++ b/tests/test_fronius_ha_rollout.py
@@ -104,6 +104,11 @@ def test_rollout_contract_fixture_covers_every_m5_08_gate() -> None:
         "ha_independent_disable",
         "compatible_rollback",
     }
+    assert payload["rollback"] == {
+        "prior_version": "0.6.55",
+        "schema_compatible": True,
+        "backup_required": True,
+    }
 
 
 def test_rollout_verifier_is_wired_into_ci_and_smoke_runbook() -> None:


### PR DESCRIPTION
Closes #228

## Summary
- require the actual predecessor `0.6.55` for the `0.6.56` rollout contract
- add a regression assertion that rejects the stale `0.6.53` value

## TDD
- RED commit `f096c0d295e21b9e4c3462d0a5fdba2ed76d8a02`: focused suite 1 failed, 6 passed because the fixture still declared `0.6.53`
- GREEN commit is this PR head

## Validation
- `python3 -m pytest tests/test_fronius_ha_rollout.py -q`: 7 passed
- `python3 scripts/check_fronius_ha_rollout.py --artifact scripts/fixtures/fronius_ha_rollout_contract_pass.json --mode contract`: PASS
- `./scripts/ci_local.sh`: PASS

## Boundaries
Static contract and tests only. No Home Assistant deployment, live I/O, credentials, or runtime behavior changes.

Docs gate: not applicable; no public behavior or architecture contract is introduced.