### PR TITLE
Accept valid IPv6 M2M certificate identities

### DIFF
--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -205,6 +205,7 @@ m2m_server_cert="${m2m_tls_root}/server-cert.pem"
 m2m_server_key="${m2m_tls_root}/server-key.pem"
 m2m_portal_client_cert="${m2m_tls_root}/portal-client-cert.pem"
 m2m_portal_client_key="${m2m_tls_root}/portal-client-key.pem"
+m2m_identity_validator="${HELIANTHUS_M2M_IDENTITY_VALIDATOR:-/usr/share/helianthus/m2m_tls_identity.py}"
 
 m2m_validate_protected_option() {
   local key expected_type
@@ -755,7 +756,7 @@ m2m_args=()
 if bashio::var.true "${m2m_graphql_enabled}"; then
   m2m_graphql_server_name=$(printf '%s' "${m2m_graphql_server_name}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
   m2m_graphql_asset_ref=$(printf '%s' "${m2m_graphql_asset_ref}" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
-  if ! [[ "${m2m_graphql_server_name}" =~ ^[A-Za-z0-9][A-Za-z0-9.-]{0,252}$ ]]; then
+  if ! python3 "${m2m_identity_validator}" "${m2m_graphql_server_name}" >/dev/null 2>&1; then
     bashio::exit.nok "M2M GraphQL requires a valid server certificate identity"
   fi
   if ! [[ "${m2m_graphql_asset_ref}" =~ ^[A-Za-z0-9._:-]{1,64}$ ]]; then

--- a/helianthus/rootfs/usr/share/helianthus/m2m_tls_identity.py
+++ b/helianthus/rootfs/usr/share/helianthus/m2m_tls_identity.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import ipaddress
+import re
+import sys
+
+
+DNS_IDENTITY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9.-]{0,252}$")
+
+
+def is_valid(value: str) -> bool:
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        return DNS_IDENTITY.fullmatch(value) is not None
+    return True
+
+
+def main(argv: list[str]) -> int:
+    return 0 if len(argv) == 2 and is_valid(argv[1]) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/test_m2m_runtime_wiring.py
+++ b/tests/test_m2m_runtime_wiring.py
@@ -132,7 +132,7 @@ def test_enabled_wrapper_executes_gateway_with_portal_semantic_switch(
         json.dumps(
             {
                 "m2m_graphql_enabled": True,
-                "m2m_graphql_server_name": "192.0.2.10",
+                "m2m_graphql_server_name": "2001:db8::10",
                 "m2m_graphql_asset_ref": "pv-asset-fixture",
             }
         ),
@@ -224,3 +224,5 @@ bashio::exit.nok() { printf 'NOK: %s\n' "$*" >&2; exit 1; }
     assert result.returncode == 0, result.stderr
     executed = argv.read_text(encoding="utf-8").splitlines()
     assert "-portal-pv-semantic-enabled=true" in executed
+    assert executed[executed.index("-m2m-graphql-server-name") + 1] == "2001:db8::10"
+    assert executed[executed.index("-portal-pv-m2m-server-name") + 1] == "2001:db8::10"

--- a/tests/test_m2m_runtime_wiring.py
+++ b/tests/test_m2m_runtime_wiring.py
@@ -4,6 +4,7 @@ import json
 import os
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 
@@ -12,6 +13,7 @@ CONFIG = ROOT / "helianthus/config.json"
 RUN = ROOT / "helianthus/rootfs/etc/services.d/helianthus-gateway/run"
 VERSION = "0.6.56"
 TLS_ROOT = "/ssl/helianthus-pv-m2m"
+M2M_IDENTITY_VALIDATOR = ROOT / "helianthus/rootfs/usr/share/helianthus/m2m_tls_identity.py"
 
 
 def test_supervisor_exposes_only_non_secret_m2m_controls_and_read_only_config() -> None:
@@ -110,6 +112,18 @@ def test_m2m_enabled_values_are_type_checked_and_never_logged() -> None:
     }
 
 
+def test_m2m_tls_identity_validator_accepts_ip_sans_and_rejects_malformed_values() -> None:
+    for identity in ("gateway.example", "192.0.2.10", "2001:db8::10"):
+        result = subprocess.run(
+            [sys.executable, str(M2M_IDENTITY_VALIDATOR), identity], check=False
+        )
+        assert result.returncode == 0
+
+    for identity in ("", "2001:db8:::10", "gateway example"):
+        result = subprocess.run(
+            [sys.executable, str(M2M_IDENTITY_VALIDATOR), identity], check=False
+        )
+        assert result.returncode == 1
 def test_enabled_wrapper_executes_gateway_with_portal_semantic_switch(
     tmp_path: Path,
 ) -> None:
@@ -217,6 +231,7 @@ bashio::exit.nok() { printf 'NOK: %s\n' "$*" >&2; exit 1; }
         ),
         "HELIANTHUS_MODBUS_OPTIONS_PATH": str(options),
         "HELIANTHUS_MODBUS_ENDPOINT_FILE": str(tmp_path / "modbus-endpoint"),
+        "HELIANTHUS_M2M_IDENTITY_VALIDATOR": str(M2M_IDENTITY_VALIDATOR),
     }
     result = subprocess.run(
         ["bash", str(wrapper)], text=True, capture_output=True, env=env, check=False


### PR DESCRIPTION
Closes #230

## Summary
- validate M2M TLS server identity as the existing DNS form or an IPv4/IPv6 address using the standard library
- pass a valid IPv6 SAN unchanged to both TLS server-name flags
- reject malformed identity values through deterministic synthetic tests

## TDD
- RED `18505a13d764b5d80d0531024de6f205d9361fdf`: 1 failed, 4 passed; current shell regex rejected `2001:db8::10`
- GREEN is this PR head

## Validation
- `python3 -m pytest tests/test_m2m_runtime_wiring.py -q`: 6 passed
- `python3 -m py_compile helianthus/rootfs/usr/share/helianthus/m2m_tls_identity.py`: PASS
- `./scripts/ci_local.sh`: PASS

## Gates and boundaries
- Docs gate: not applicable; current docs already describe an exact DNS name or IP SAN, and this restores that implementation contract.
- No certificate changes, Home Assistant deployment, live I/O, credentials, gateway semantic changes, or protocol changes.