### PR TITLE
Use configurable options path for eeBUS wrapper validation

### DIFF
--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -45,8 +45,8 @@ fi
 # Supervisor cache-invalidation bug appears specific to this key and reproduces
 # only after the addon options POST without a container recreation. When
 # bashio returns empty, parse the JSON directly via jq as the source of truth.
-if [ -z "${proxy_listen_addr}" ] && [ -f /data/options.json ] && command -v jq >/dev/null 2>&1; then
-  proxy_listen_addr_fallback=$(jq -r '.proxy_listen_addr // empty' /data/options.json 2>/dev/null || true)
+if [ -z "${proxy_listen_addr}" ] && [ -f "${addon_options_path}" ] && command -v jq >/dev/null 2>&1; then
+  proxy_listen_addr_fallback=$(jq -r '.proxy_listen_addr // empty' "${addon_options_path}" 2>/dev/null || true)
   if [ -n "${proxy_listen_addr_fallback}" ] && [ "${proxy_listen_addr_fallback}" != "null" ]; then
     bashio::log.warning "bashio::config 'proxy_listen_addr' returned empty; falling back to /data/options.json (value=${proxy_listen_addr_fallback}). Supervisor cache-invalidation bug — see EBUSD-VERIFICATION-2026-05-10.md F-1."
     proxy_listen_addr="${proxy_listen_addr_fallback}"
@@ -148,7 +148,7 @@ unset MODBUS_TCP_ENDPOINT modbus_eval modbus_validation_status modbus_pre_exec_s
 # Validate protected eeBUS values before bashio captures them. Bash command
 # substitution cannot preserve NUL, and textual bashio output cannot retain
 # JSON scalar types, so validation after capture would be too late.
-eebus_options_path="/data/options.json"
+eebus_options_path="${addon_options_path}"
 eebus_validate_protected_option() {
   local key expected_type
   key="$1"

--- a/tests/test_eebus_admin_wrapper.py
+++ b/tests/test_eebus_admin_wrapper.py
@@ -127,7 +127,6 @@ bashio::exit.nok() { printf 'NOK: %s\n' "$*" >&2; exit 1; }
     text = text.replace("/data/source_addr.last", "${TEST_SOURCE_STATE}")
     text = text.replace("/etc/machine-id", "${TEST_MACHINE_ID}")
     text = text.replace('interface_id_path="/sys/class/net/${eebus_interface}/address"', 'interface_id_path="${TEST_INTERFACE_ID_PATH}"')
-    text = text.replace('eebus_options_path="/data/options.json"', 'eebus_options_path="${TEST_EEBUS_OPTIONS}"')
     text = text.replace("/usr/share/helianthus/eebus_admin_credentials.py", "${TEST_LEGACY_HELPER}")
     text = text.replace("/run/helianthus/eebus-admin", "${TEST_LEGACY_RUNTIME}")
     wrapper.write_text(prelude + "\n" + text, encoding="utf-8")
@@ -139,6 +138,7 @@ bashio::exit.nok() { printf 'NOK: %s\n' "$*" >&2; exit 1; }
         "TEST_INTERFACE_ID_PATH": str(interface_id),
         "TEST_MACHINE_ID": str(tmp_path / "machine-id"),
         "TEST_EEBUS_OPTIONS": str(options),
+        "HELIANTHUS_OPTIONS_PATH": str(options),
         "HELIANTHUS_RUNTIME_STATE_WRAPPER": str(ROOT / "helianthus/rootfs/usr/share/helianthus/check_runtime_state_wrapper.py"),
         "HELIANTHUS_RUNTIME_STATE_PATH": str(tmp_path / "runtime-state.json"),
         "HELIANTHUS_LEGACY_INSTANCE_GUID_PATH": str(tmp_path / "instance-guid"),
@@ -155,3 +155,10 @@ bashio::exit.nok() { printf 'NOK: %s\n' "$*" >&2; exit 1; }
     for term in REMOVED_WRAPPER_TERMS:
         assert term not in rendered
     assert "eeBUS admin" not in rendered
+
+
+def test_eebus_protected_options_share_the_configurable_options_path() -> None:
+    run = RUN.read_text(encoding="utf-8")
+
+    assert run.count('"${HELIANTHUS_OPTIONS_PATH:-/data/options.json}"') == 2
+    assert 'eebus_options_path="${HELIANTHUS_OPTIONS_PATH:-/data/options.json}"' in run

--- a/tests/test_eebus_admin_wrapper.py
+++ b/tests/test_eebus_admin_wrapper.py
@@ -160,5 +160,6 @@ bashio::exit.nok() { printf 'NOK: %s\n' "$*" >&2; exit 1; }
 def test_eebus_protected_options_share_the_configurable_options_path() -> None:
     run = RUN.read_text(encoding="utf-8")
 
-    assert run.count('"${HELIANTHUS_OPTIONS_PATH:-/data/options.json}"') == 2
-    assert 'eebus_options_path="${HELIANTHUS_OPTIONS_PATH:-/data/options.json}"' in run
+    assert 'addon_options_path="${HELIANTHUS_OPTIONS_PATH:-/data/options.json}"' in run
+    assert 'eebus_options_path="${addon_options_path}"' in run
+    assert '[ -f "${addon_options_path}" ]' in run


### PR DESCRIPTION
Closes #232

## Summary
- route eeBUS protected-option validation and proxy-listen fallback through the existing `HELIANTHUS_OPTIONS_PATH` override
- remove the test-only replacement that masked the hard-coded path

## TDD
- RED `8b20ca553d6fe7b9d1467e8de29f36d092070df9`: 1 failed, 4 passed because eeBUS validation still used `/data/options.json`
- GREEN is this PR head

## Validation
- `python3 -m pytest tests/test_eebus_admin_wrapper.py -q`: 5 passed
- `./scripts/ci_local.sh`: PASS

## Gates and boundaries
- Docs gate: not applicable; this restores the existing testability/configuration override without schema or public behavior changes.
- No Home Assistant deployment, live I/O, credentials, option schema change, or protocol behavior change.