### PR TITLE
test(addon): close INT-02 verification gaps

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -70,7 +70,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          python3 -m pip install --quiet --user pytest
           python3 scripts/check_source_addr_wrapper.py
+          python3 -m pytest tests/test_source_addr_wrapper_m4.py -q
 
       - name: Validate persistent eeBUS wrapper wiring
         shell: bash

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -15,3 +15,22 @@
 
 - Prefer short, declarative documentation.
 - Avoid implementation details until functionality is added.
+
+## Validation
+
+Run `./scripts/ci_local.sh` for the repository's complete local CI and
+`python3 -m pytest tests -q` for the default test suite. Resolver tests use
+mocked HTTP responses, deny unmocked registry access, and skip the public GHCR
+probe by default.
+
+Run the public release metadata probe explicitly when outbound access to
+`ghcr.io` is available:
+
+```sh
+HELIANTHUS_RUN_PUBLIC_GHCR_PROBE=1 python3 -m pytest tests/test_fronius_ha_rollout.py::test_public_release_manifest_probe_resolves_existing_tag -q
+```
+
+That command anonymously reads a pull token and the existing public `0.6.56`
+OCI index for `linux/arm64`. It does not pull or execute an image, authenticate,
+publish a manifest, or change a tag. Standard local and pull-request test runs
+do not make this GHCR request.

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -49,6 +49,7 @@ python3 scripts/check_eebus_ha_network_proof.py --artifact scripts/fixtures/eebu
 
 echo "==> source address wrapper migration"
 python3 scripts/check_source_addr_wrapper.py
+python3 -m pytest tests/test_source_addr_wrapper_m4.py -q
 
 echo "==> persistent eeBUS wrapper wiring"
 python3 scripts/check_eebus_wrapper.py

--- a/tests/test_fronius_ha_rollout.py
+++ b/tests/test_fronius_ha_rollout.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import subprocess
 import sys
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 VERSION = "0.6.56"
@@ -23,6 +25,60 @@ PUBLICATION = {
     "manifest_digest": MANIFEST_DIGEST,
     "platform_digest": PLATFORM_DIGEST,
 }
+
+
+class _Response:
+    def __init__(self, raw: bytes, headers: dict[str, str] | None = None) -> None:
+        self._raw = raw
+        self.headers = headers or {}
+
+    def __enter__(self):  # noqa: ANN204
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self, _limit: int) -> bytes:
+        return self._raw
+
+
+def _mock_registry(
+    monkeypatch: pytest.MonkeyPatch,
+    verifier,
+    *,
+    token_payload: object = None,
+    manifest_payload: object = None,
+    manifest_raw: bytes | None = None,
+    manifest_digest: str = MANIFEST_DIGEST,
+) -> list:
+    if token_payload is None:
+        token_payload = {"token": "fixture-token"}
+    if manifest_payload is None:
+        manifest_payload = {
+            "manifests": [
+                {
+                    "digest": "sha256:" + "c" * 64,
+                    "platform": {"os": "linux", "architecture": "amd64"},
+                },
+                {
+                    "digest": PLATFORM_DIGEST,
+                    "platform": {"os": "linux", "architecture": "arm64"},
+                },
+            ]
+        }
+    requests = []
+
+    def fake_urlopen(request, *, timeout: int):  # noqa: ANN001, ANN202
+        requests.append((request, timeout))
+        if len(requests) == 1:
+            return _Response(json.dumps(token_payload).encode())
+        raw = manifest_raw
+        if raw is None:
+            raw = json.dumps(manifest_payload).encode()
+        return _Response(raw, {"Docker-Content-Digest": manifest_digest})
+
+    monkeypatch.setattr(verifier, "urlopen", fake_urlopen)
+    return requests
 
 
 def _verifier_module():  # noqa: ANN202
@@ -180,3 +236,155 @@ def test_rollout_verifier_rejects_non_rfc3339_timestamp() -> None:
         payload = _live_payload()
         payload["live"]["installed_at"] = invalid
         assert verifier.validate(payload, "lab", publication=PUBLICATION)
+
+
+@pytest.mark.parametrize("token_payload", ({}, {"token": ""}, {"token": 7}))
+def test_publication_resolver_rejects_missing_token(
+    monkeypatch: pytest.MonkeyPatch, token_payload: object
+) -> None:
+    verifier = _verifier_module()
+    _mock_registry(monkeypatch, verifier, token_payload=token_payload)
+
+    with pytest.raises(ValueError, match="pull token missing"):
+        verifier.resolve_publication(
+            PUBLICATION["image_repository"], VERSION, PUBLICATION["target_platform"]
+        )
+
+
+@pytest.mark.parametrize(
+    ("manifest_raw", "manifest_payload", "expected_error"),
+    (
+        (b"x" * 1_048_577, None, (ValueError,)),
+        (b"not-json", None, (json.JSONDecodeError,)),
+        (None, {"manifests": {}}, (ValueError,)),
+    ),
+)
+def test_publication_resolver_rejects_invalid_or_oversized_index(
+    monkeypatch: pytest.MonkeyPatch,
+    manifest_raw: bytes | None,
+    manifest_payload: object,
+    expected_error: tuple[type[Exception], ...],
+) -> None:
+    verifier = _verifier_module()
+    _mock_registry(
+        monkeypatch,
+        verifier,
+        manifest_raw=manifest_raw,
+        manifest_payload=manifest_payload,
+    )
+
+    with pytest.raises(expected_error):
+        verifier.resolve_publication(
+            PUBLICATION["image_repository"], VERSION, PUBLICATION["target_platform"]
+        )
+
+
+def test_publication_resolver_rejects_invalid_index_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = _verifier_module()
+    _mock_registry(monkeypatch, verifier, manifest_digest="sha256:not-a-digest")
+
+    with pytest.raises(ValueError, match="manifest response is invalid"):
+        verifier.resolve_publication(
+            PUBLICATION["image_repository"], VERSION, PUBLICATION["target_platform"]
+        )
+
+
+@pytest.mark.parametrize(
+    "matching_descriptors",
+    (
+        [],
+        [
+            {
+                "digest": PLATFORM_DIGEST,
+                "platform": {"os": "linux", "architecture": "arm64"},
+            },
+            {
+                "digest": "sha256:" + "d" * 64,
+                "platform": {"os": "linux", "architecture": "arm64"},
+            },
+        ],
+    ),
+)
+def test_publication_resolver_rejects_absent_or_ambiguous_platform(
+    monkeypatch: pytest.MonkeyPatch, matching_descriptors: list[dict]
+) -> None:
+    verifier = _verifier_module()
+    manifest = {
+        "manifests": [
+            {
+                "digest": "sha256:" + "c" * 64,
+                "platform": {"os": "linux", "architecture": "amd64"},
+            },
+            *matching_descriptors,
+        ]
+    }
+    _mock_registry(monkeypatch, verifier, manifest_payload=manifest)
+
+    with pytest.raises(ValueError, match="platform is missing or ambiguous"):
+        verifier.resolve_publication(
+            PUBLICATION["image_repository"], VERSION, PUBLICATION["target_platform"]
+        )
+
+
+def test_publication_resolver_rejects_malformed_platform_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = _verifier_module()
+    manifest = {
+        "manifests": [
+            {
+                "digest": "sha256:invalid",
+                "platform": {"os": "linux", "architecture": "arm64"},
+            }
+        ]
+    }
+    _mock_registry(monkeypatch, verifier, manifest_payload=manifest)
+
+    with pytest.raises(ValueError, match="platform digest is invalid"):
+        verifier.resolve_publication(
+            PUBLICATION["image_repository"], VERSION, PUBLICATION["target_platform"]
+        )
+
+
+def test_publication_resolver_binds_exact_index_and_platform_digests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    verifier = _verifier_module()
+    requests = _mock_registry(monkeypatch, verifier)
+
+    publication = verifier.resolve_publication(
+        PUBLICATION["image_repository"], VERSION, PUBLICATION["target_platform"]
+    )
+
+    assert publication == PUBLICATION
+    assert len(requests) == 2
+    token_request, token_timeout = requests[0]
+    manifest_request, manifest_timeout = requests[1]
+    assert token_timeout == manifest_timeout == 30
+    assert token_request.full_url.startswith("https://ghcr.io/token?")
+    assert "repository%3Aproject-helianthus%2Fhelianthus-ha-addon%3Apull" in (
+        token_request.full_url
+    )
+    assert manifest_request.full_url.endswith(
+        "/project-helianthus/helianthus-ha-addon/manifests/0.6.56"
+    )
+    assert manifest_request.get_header("Authorization") == "Bearer fixture-token"
+    assert "application/vnd.oci.image.index.v1+json" in manifest_request.get_header(
+        "Accept"
+    )
+
+
+def test_public_release_manifest_probe_resolves_existing_tag() -> None:
+    verifier = _verifier_module()
+
+    publication = verifier.resolve_publication(
+        PUBLICATION["image_repository"], VERSION, PUBLICATION["target_platform"]
+    )
+
+    assert publication["image_repository"] == PUBLICATION["image_repository"]
+    assert publication["image_tag"] == VERSION
+    assert publication["target_platform"] == PUBLICATION["target_platform"]
+    assert verifier.DIGEST_RE.fullmatch(publication["manifest_digest"])
+    assert verifier.DIGEST_RE.fullmatch(publication["platform_digest"])

--- a/tests/test_fronius_ha_rollout.py
+++ b/tests/test_fronius_ha_rollout.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from copy import deepcopy
 import importlib.util
 import json
+import os
 from pathlib import Path
 import subprocess
 import sys
+import urllib.request
 
 import pytest
 
@@ -25,6 +27,23 @@ PUBLICATION = {
     "manifest_digest": MANIFEST_DIGEST,
     "platform_digest": PLATFORM_DIGEST,
 }
+PUBLIC_GHCR_PROBE_ENV = "HELIANTHUS_RUN_PUBLIC_GHCR_PROBE"
+_ORIGINAL_URLOPEN = urllib.request.urlopen
+
+
+@pytest.fixture(autouse=True)
+def _deny_unmocked_registry_access(monkeypatch: pytest.MonkeyPatch) -> None:
+    def denied_urlopen(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("unit tests must not access the public registry")
+
+    monkeypatch.setattr(urllib.request, "urlopen", denied_urlopen)
+
+
+@pytest.fixture
+def _public_ghcr_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    if os.environ.get(PUBLIC_GHCR_PROBE_ENV) != "1":
+        pytest.skip(f"set {PUBLIC_GHCR_PROBE_ENV}=1 to run the public GHCR probe")
+    monkeypatch.setattr(urllib.request, "urlopen", _ORIGINAL_URLOPEN)
 
 
 class _Response:
@@ -376,7 +395,18 @@ def test_publication_resolver_binds_exact_index_and_platform_digests(
     )
 
 
-def test_public_release_manifest_probe_resolves_existing_tag() -> None:
+def test_default_resolver_suite_denies_unmocked_registry_access() -> None:
+    verifier = _verifier_module()
+
+    with pytest.raises(AssertionError, match="must not access the public registry"):
+        verifier.resolve_publication(
+            PUBLICATION["image_repository"], VERSION, PUBLICATION["target_platform"]
+        )
+
+
+def test_public_release_manifest_probe_resolves_existing_tag(
+    _public_ghcr_probe: None,
+) -> None:
     verifier = _verifier_module()
 
     publication = verifier.resolve_publication(

--- a/tests/test_m2m_runtime_wiring.py
+++ b/tests/test_m2m_runtime_wiring.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / "helianthus/config.json"
@@ -124,8 +126,11 @@ def test_m2m_tls_identity_validator_accepts_ip_sans_and_rejects_malformed_values
             [sys.executable, str(M2M_IDENTITY_VALIDATOR), identity], check=False
         )
         assert result.returncode == 1
-def test_enabled_wrapper_executes_gateway_with_portal_semantic_switch(
-    tmp_path: Path,
+
+
+@pytest.mark.parametrize("m2m_enabled", (False, True))
+def test_wrapper_executes_exact_m2m_bundle_only_when_enabled(
+    tmp_path: Path, m2m_enabled: bool
 ) -> None:
     wrapper = tmp_path / "run-under-test.sh"
     gateway = tmp_path / "gateway.py"
@@ -145,7 +150,7 @@ def test_enabled_wrapper_executes_gateway_with_portal_semantic_switch(
     options.write_text(
         json.dumps(
             {
-                "m2m_graphql_enabled": True,
+                "m2m_graphql_enabled": m2m_enabled,
                 "m2m_graphql_server_name": "2001:db8::10",
                 "m2m_graphql_asset_ref": "pv-asset-fixture",
             }
@@ -238,6 +243,41 @@ bashio::exit.nok() { printf 'NOK: %s\n' "$*" >&2; exit 1; }
     )
     assert result.returncode == 0, result.stderr
     executed = argv.read_text(encoding="utf-8").splitlines()
-    assert "-portal-pv-semantic-enabled=true" in executed
-    assert executed[executed.index("-m2m-graphql-server-name") + 1] == "2001:db8::10"
-    assert executed[executed.index("-portal-pv-m2m-server-name") + 1] == "2001:db8::10"
+    m2m_argv = [
+        "-m2m-graphql-listen",
+        "0.0.0.0:8443",
+        "-m2m-graphql-server-name",
+        "2001:db8::10",
+        "-m2m-graphql-client-ca",
+        str(tls_root / "ca.pem"),
+        "-m2m-graphql-server-cert",
+        str(tls_root / "server-cert.pem"),
+        "-m2m-graphql-server-key",
+        str(tls_root / "server-key.pem"),
+        "-m2m-graphql-allowed-assets",
+        "pv-asset-fixture",
+        "-m2m-graphql-known-assets",
+        "pv-asset-fixture",
+        "-portal-pv-semantic-enabled=true",
+        "-portal-pv-m2m-url",
+        "https://127.0.0.1:8443/graphql/m2m/v1",
+        "-portal-pv-m2m-server-name",
+        "2001:db8::10",
+        "-portal-pv-m2m-ca",
+        str(tls_root / "ca.pem"),
+        "-portal-pv-m2m-client-cert",
+        str(tls_root / "portal-client-cert.pem"),
+        "-portal-pv-m2m-client-key",
+        str(tls_root / "portal-client-key.pem"),
+        "-portal-pv-asset-ref",
+        "pv-asset-fixture",
+    ]
+    if m2m_enabled:
+        assert executed[executed.index("-m2m-graphql-listen") :] == m2m_argv
+        assert "M2M GraphQL runtime: enabled" in log.read_text(encoding="utf-8")
+    else:
+        assert not any(
+            arg.startswith("-m2m-graphql-") or arg.startswith("-portal-pv-")
+            for arg in executed
+        )
+        assert "M2M GraphQL runtime: disabled" in log.read_text(encoding="utf-8")


### PR DESCRIPTION
Issues #183, #218, and #221 leave three verification gaps around behavior already present on `main`: the secret-persistence verifier is absent from standard CI, GHCR publication resolution lacks direct HTTP failure coverage, and the execution-level M2M test only checks three selected arguments.

This change runs the existing secret-persistence contract test in local and hosted CI, adds offline mocked resolver coverage, retains one explicit opt-in anonymous read-only probe of the existing `0.6.56` public release index, and compares the complete enabled M2M argument bundle while proving that the disabled path stays inert.

Closes #183
Closes #218
Closes #221

## Acceptance evidence

- #183: `tests/test_source_addr_wrapper_m4.py` now runs in `pr-ci` and `ci_local.sh`; its match, no-match, scanner-error, empty/missing-input, and post-scan continuation cases remain intact. The five-platform image build matrix is unchanged.
- #218: mocked token and manifest responses cover missing tokens, oversized and malformed indexes, invalid content digest, absent and ambiguous platforms, malformed child digest, and valid exact index/platform digest binding. Default tests deny unmocked registry access and skip the live probe. `CONVENTIONS.md` documents the explicit opt-in command and its anonymous GET-only boundary; that command resolves the existing public `0.6.56` `linux/arm64` publication.
- #221: the enabled wrapper test compares every M2M and Portal argument, including fixed TLS files, loopback URL, server name, asset reference, and boolean flag. Its disabled case passes protected option values but emits no M2M or Portal arguments. The wrapper still has exactly one direct gateway `exec`.

## Validation

- `./scripts/ci_local.sh` — PASS (`26 passed, 1 skipped` in the Fronius/M2M stage)
- `HTTPS_PROXY=http://127.0.0.1:9 HTTP_PROXY=http://127.0.0.1:9 ALL_PROXY=http://127.0.0.1:9 NO_PROXY='' python3 -m pytest tests -q` — 89 passed, 1 skipped; proves the default suite has no real registry dependency
- `HELIANTHUS_RUN_PUBLIC_GHCR_PROBE=1 python3 -m pytest tests/test_fronius_ha_rollout.py::test_public_release_manifest_probe_resolves_existing_tag -q` — 1 passed
- `git diff --check` — PASS

## Gates and residual risk

- Documentation gate: satisfied in `CONVENTIONS.md` with the exact opt-in integration command and network boundary; externally visible packaging, configuration, startup behavior, and operator workflow are unchanged.
- Transport/conformance gate: not applicable; no transport or runtime implementation changed.
- Smoke gate: offline executable tests and the bounded public registry metadata probe are sufficient for this verification-only change. No add-on installation, private context, credentials, or live device was used.
- Residual: only the explicit opt-in public-release probe depends on GHCR availability and fails closed when registry metadata cannot be verified. Default tests and PR CI remain offline for this resolver contract.
