### PR TITLE
runtime-state: remove add-on bootstrap writer

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -87,17 +87,17 @@ jobs:
         run: |
           set -euo pipefail
           # Sandbox the wrapper into a temp dir so CI never touches the
-          # runner's /data/ (a real /data/instance_guid would trip AD09a;
-          # case-3 fall-through would create /data/runtime_state.json on
-          # the runner). Codex P2 follow-up on PR #127.
+          # runner's /data/ (a real /data/instance_guid would trip AD09a).
+          # The wrapper is read-only for runtime_state.json; fresh identity is
+          # handed to the gateway for sole-writer eager persistence.
           tmp_state_dir=$(mktemp -d)
           trap 'rm -rf "${tmp_state_dir}"' EXIT
           HELIANTHUS_RUNTIME_STATE_PATH="${tmp_state_dir}/runtime_state.json" \
           HELIANTHUS_LEGACY_INSTANCE_GUID_PATH="${tmp_state_dir}/instance_guid" \
           HELIANTHUS_MIGRATION_MARKER_PATH="${tmp_state_dir}/.helianthus_migration_required" \
             python3 scripts/check_runtime_state_wrapper.py
-          # Confirm the case-3 bootstrap landed in the temp dir, not /data.
-          test -f "${tmp_state_dir}/runtime_state.json"
+          # Confirm neither the sandbox path nor /data received a wrapper write.
+          test ! -e "${tmp_state_dir}/runtime_state.json"
           test ! -e /data/runtime_state.json || {
             echo "FAIL: wrapper wrote /data/runtime_state.json on the CI runner"
             exit 1
@@ -109,7 +109,7 @@ jobs:
           set -euo pipefail
           # The contract test suite (covers all 5 AD09b read-precedence
           # cases, AD09a halt details, AD25/AD26/AD27 invariants, and the
-          # case-3 bootstrap persistence path) — each test uses tmp_path
+          # case-3 sole-writer handoff path) — each test uses tmp_path
           # fixtures + explicit HELIANTHUS_* env-overrides, so it never
           # touches the runner's /data/.
           python3 -m pip install --quiet --user pytest

--- a/helianthus/rootfs/etc/services.d/helianthus-gateway/run
+++ b/helianthus/rootfs/etc/services.d/helianthus-gateway/run
@@ -652,6 +652,14 @@ gateway_supports_flag() {
   binary_supports_flag "${gateway_bin}" "$1"
 }
 
+# The wrapper creates an identity only for this invocation; durable ownership
+# belongs exclusively to the gateway's eager runtime-state writer. Refuse to
+# start a packaged binary that cannot receive that identity rather than adding
+# a wrapper-side persistence fallback.
+if ! gateway_supports_flag "instance-guid"; then
+  bashio::exit.nok "Packaged gateway binary does not support required -instance-guid; refusing startup without gateway-owned runtime-state persistence"
+fi
+
 # Gate `-enable-static-seed-table` on gateway support — the flag is
 # only present in builds containing P3 wiring. Older pinned gateway
 # binaries would fail flag parsing at startup. (Codex P1+P2 follow-up

--- a/helianthus/rootfs/usr/share/helianthus/check_runtime_state_wrapper.py
+++ b/helianthus/rootfs/usr/share/helianthus/check_runtime_state_wrapper.py
@@ -36,7 +36,6 @@ import re
 import sys
 import time
 import uuid
-from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -302,71 +301,6 @@ def write_migration_marker(
             pass  # happy-path: temp already consumed by os.replace above
 
 
-def persist_bootstrap_runtime_state(
-    runtime_state_path: str,
-    instance_guid: str,
-    written_at: str,
-) -> bool:
-    """Write a minimal schema-valid runtime_state.json for case-3 bootstrap.
-
-    Codex P2 follow-up on PR #127: a /data/helianthus-gateway override that
-    predates M2_GATEWAY_LOADER will not write runtime_state.json itself, so
-    a fresh install that hits case 3 (both files absent → generate UUIDv4)
-    would re-enter case 3 on every restart and present a different HA
-    identity. Persisting from the wrapper bootstraps the file once; the
-    pinned (M2-aware) gateway then takes over via eager-persist and adds
-    ebus.* sections. Older overrides simply leave the file alone, but
-    identity is now stable across restarts because the wrapper itself
-    reads its own bootstrap on the next boot.
-
-    This is the ONLY non-gateway writer of runtime_state.json. It writes
-    only the fields the schema requires (schema_version, meta) and never
-    touches ebus.* — the gateway owns those.
-
-    Atomic temp+rename within the target file's directory. Returns True on
-    success, False on any I/O error (caller logs and continues — failing
-    closed here would block fresh installs).
-    """
-    body = (
-        json.dumps(
-            {
-                "schema_version": 1,
-                "meta": {
-                    "instance_guid": instance_guid,
-                    "written_at": written_at,
-                },
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n"
-    )
-    target = Path(runtime_state_path)
-    try:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        tmp = target.with_suffix(target.suffix + ".tmp")
-        with open(tmp, "w", encoding="utf-8") as fp:
-            fp.write(body)
-            fp.flush()
-            try:
-                os.fsync(fp.fileno())
-            except (OSError, AttributeError):
-                pass  # best-effort fsync
-        os.replace(tmp, target)
-        return True
-    except OSError:
-        # Best-effort: the gateway will still receive -instance-guid for
-        # this run; identity churn becomes an issue only across restarts,
-        # and the operator will see HELIANTHUS_FRESH_IDENTITY each time
-        # which is the established case-3 signal.
-        try:
-            tmp.unlink()
-        except (FileNotFoundError, NameError, OSError):
-            # Successful replace consumes tmp; unlink fails benignly here.
-            pass
-        return False
-
-
 def emit_log_lines(lines: list[str], stream=None) -> None:
     """Write the structured log lines to the Supervisor stdout stream.
 
@@ -399,8 +333,9 @@ def main(argv: list[str] | None = None) -> int:
       - Reads /data/runtime_state.json (with AD26 ENOENT retries).
       - On AD09a halt: writes /data/.helianthus_migration_required marker file,
         emits HELIANTHUS_MIGRATION_REQUIRED log token, exits with code 1.
-      - On case (3) fresh generation: emits HELIANTHUS_FRESH_IDENTITY warn
-        and bootstrap-persists the generated GUID into runtime_state.json.
+      - On case (3) fresh generation: emits HELIANTHUS_FRESH_IDENTITY and
+        passes the one generated GUID to the gateway. The gateway is the
+        sole writer and eagerly persists it.
 
     Standalone invocation (no args) is also a CI smoke check: it runs the
     resolver against runtime defaults; if the system has no /data/ dir,
@@ -430,26 +365,6 @@ def main(argv: list[str] | None = None) -> int:
             )
         emit_log_lines(result.log_lines)
         return EXIT_MIGRATION_REQUIRED
-
-    # Case 3 (fresh generation): persist the bootstrap runtime_state.json
-    # before handing identity to the gateway. Without this, an old
-    # /data/helianthus-gateway override that predates M2_GATEWAY_LOADER
-    # would never write the file, and every restart would generate a
-    # different identity (Codex P2 on PR #127). The pinned gateway will
-    # overwrite this file with the full schema during eager-persist.
-    if result.source == IDENTITY_SOURCE_GENERATED:
-        written_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        if not persist_bootstrap_runtime_state(
-            runtime_state_path=runtime_state_path,
-            instance_guid=result.guid,
-            written_at=written_at,
-        ):
-            print(
-                "WARN HELIANTHUS_BOOTSTRAP_PERSIST_FAILED "
-                f"path={runtime_state_path}; identity may churn across restarts "
-                "if the pinned gateway also fails to write runtime_state.json",
-                file=sys.stderr,
-            )
 
     # Case (1/3/4) success — emit log lines (warn on case 3 fresh-id;
     # warn on case 4 mismatch; silent on case 1).

--- a/scripts/check_source_addr_wrapper.py
+++ b/scripts/check_source_addr_wrapper.py
@@ -100,19 +100,22 @@ def _write_gateway_stub(path: Path, mode: str) -> None:
         # `old` predates startup-source-override AND -instance-guid-source —
         # the bash run script must suppress -instance-guid-source via the
         # AD27 compatibility gate (Codex P2 follow-up on PR #127).
-        "old": "Usage of gateway:\n  -source-addr string\n",
+        "old": "Usage of gateway:\n  -source-addr string\n  -instance-guid string\n",
         # `new` advertises both the M2_GATEWAY_LOADER -instance-guid-source
         # flag and the source-override flags. The bash gate must pass through
         # the provenance tag in this mode.
         "new": (
             "Usage of gateway:\n"
             "  -source-addr string\n"
+            "  -instance-guid string\n"
             "  -startup-source-override string\n"
             "  -startup-source-override-validate\n"
             "  -instance-guid-source string\n"
             "  -semantic-cache-path string\n"
         ),
     }
+    if mode == "missing-instance-guid":
+        help_by_mode[mode] = "Usage of gateway:\n  -source-addr string\n"
     script = f"""#!/usr/bin/env python3
 from pathlib import Path
 import os
@@ -155,6 +158,8 @@ def _run_wrapper_case(
     proxy_endpoint: str = "",
     proxy_listen_addr: str = "0.0.0.0:19001",
     expect_success: bool = True,
+    fresh_runtime_state: bool = False,
+    assert_runtime_state_absent: bool = False,
 ) -> tuple[list[str], str, bool, str, str]:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
@@ -173,21 +178,22 @@ def _run_wrapper_case(
         # wrapper's path env vars into the temp sandbox so it reads our test
         # GUID without touching /data/.
         runtime_state_file = tmp / "runtime_state.json"
-        runtime_state_file.write_text(
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "meta": {
-                        "instance_guid": VALID_INSTANCE_GUID,
-                        "written_at": "2026-05-10T00:00:00Z",
+        if not fresh_runtime_state:
+            runtime_state_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "meta": {
+                            "instance_guid": VALID_INSTANCE_GUID,
+                            "written_at": "2026-05-10T00:00:00Z",
+                        },
                     },
-                },
-                indent=2,
-                sort_keys=True,
+                    indent=2,
+                    sort_keys=True,
+                )
+                + "\n",
+                encoding="utf-8",
             )
-            + "\n",
-            encoding="utf-8",
-        )
         instance_guid_file = tmp / "instance_guid"
         # Legacy file deliberately absent; runtime_state.json is the source.
         legacy_marker_file = tmp / "migration_marker"
@@ -241,6 +247,11 @@ def _run_wrapper_case(
             _assert(
                 result.returncode != 0,
                 f"wrapper case source_addr={source_addr!r} gateway_mode={gateway_mode!r} unexpectedly succeeded",
+            )
+        if assert_runtime_state_absent:
+            _assert(
+                not runtime_state_file.exists(),
+                "wrapper-side startup failure must not create runtime_state.json",
             )
 
         argv = argv_file.read_text(encoding="utf-8").splitlines() if argv_file.exists() else []
@@ -595,7 +606,18 @@ def _check_runtime_cases() -> None:
     _assert(argv == [], "unknown gateway exact source must fail before invoking gateway")
     _assert("-source-addr" not in argv, "unknown gateway exact source must not use legacy active source input")
     _assert(not state_exists, "unknown gateway exact source must not create source state file")
-    _assert("requires gateway startup source override validation support" in stderr, "unknown gateway failure must explain missing startup override support")
+    _assert("does not support required -instance-guid" in stderr, "unknown gateway failure must explain the required identity interface")
+
+    argv, _logs, state_exists, _state_content, stderr = _run_wrapper_case(
+        source_addr="auto",
+        gateway_mode="missing-instance-guid",
+        expect_success=False,
+        fresh_runtime_state=True,
+        assert_runtime_state_absent=True,
+    )
+    _assert(argv == [], "gateway lacking -instance-guid must fail before invocation")
+    _assert(not state_exists, "required-interface failure must not create wrapper state")
+    _assert("does not support required -instance-guid" in stderr, "required-interface failure must name -instance-guid")
 
 
 def main() -> int:

--- a/tests/test_eebus_admin_wrapper.py
+++ b/tests/test_eebus_admin_wrapper.py
@@ -90,7 +90,7 @@ def test_eebus_runtime_keeps_pairing_without_admin_argv_logs_or_environment(
     gateway.write_text(
         "#!/usr/bin/env python3\nimport os, pathlib, sys\n"
         "if '--help' in sys.argv:\n"
-        "    sys.stderr.write('\\n'.join('-' + value for value in ('eebus-enabled', 'eebus-listen-port', 'eebus-interfaces', 'eebus-subnets', 'eebus-state-root', 'eebus-discovery-enabled', 'eebus-remote-ski-allowlist', 'eebus-pairing-window-mode', 'instance-guid-source', 'semantic-cache-path')) + '\\n')\n"
+        "    sys.stderr.write('\\n'.join('-' + value for value in ('eebus-enabled', 'eebus-listen-port', 'eebus-interfaces', 'eebus-subnets', 'eebus-state-root', 'eebus-discovery-enabled', 'eebus-remote-ski-allowlist', 'eebus-pairing-window-mode', 'instance-guid', 'instance-guid-source', 'semantic-cache-path')) + '\\n')\n"
         "    raise SystemExit(0)\n"
         "pathlib.Path(os.environ['TEST_ARGV']).write_text('\\n'.join(sys.argv[1:]), encoding='utf-8')\n",
         encoding="utf-8",

--- a/tests/test_m2m_runtime_wiring.py
+++ b/tests/test_m2m_runtime_wiring.py
@@ -172,6 +172,7 @@ def test_wrapper_executes_exact_m2m_bundle_only_when_enabled(
         "portal-pv-m2m-client-cert",
         "portal-pv-m2m-client-key",
         "portal-pv-asset-ref",
+        "instance-guid",
         "instance-guid-source",
     )
     gateway.write_text(

--- a/tests/test_runtime_state_wrapper_red.py
+++ b/tests/test_runtime_state_wrapper_red.py
@@ -21,6 +21,7 @@ Plan: runtime-state-w19-26.locked. ADs referenced inline per case.
 from __future__ import annotations
 
 import importlib.util
+import builtins
 import io
 import json
 import os
@@ -319,88 +320,85 @@ def test_ad26_enoent_retry_budget(tmp_path: Path) -> None:
 
 
 # -----------------------------------------------------------------------------
-# Case-3 bootstrap persistence (Codex P2 follow-up on PR #127).
+# Sole-writer boundary: the wrapper only reads runtime_state.json.
 # -----------------------------------------------------------------------------
 
 
-def test_case3_bootstrap_persists_runtime_state(tmp_path: Path) -> None:
-    """Case 3 must write runtime_state.json so identity is stable across restarts
-    even when /data/helianthus-gateway predates M2_GATEWAY_LOADER and never
-    writes the file itself."""
+def test_case3_passes_one_generated_guid_without_runtime_state_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Fresh startup leaves durable runtime-state ownership to the gateway."""
     module = _wrapper_module()
     rs_path = tmp_path / "runtime_state.json"
     legacy_path = tmp_path / "instance_guid"
     marker_path = tmp_path / "marker"
-    monkey_env = {
-        "HELIANTHUS_RUNTIME_STATE_PATH": str(rs_path),
-        "HELIANTHUS_LEGACY_INSTANCE_GUID_PATH": str(legacy_path),
-        "HELIANTHUS_MIGRATION_MARKER_PATH": str(marker_path),
-    }
-    saved = {k: os.environ.get(k) for k in monkey_env}
-    os.environ.update(monkey_env)
-    try:
-        rc = module.main([])
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
+    monkeypatch.setenv("HELIANTHUS_RUNTIME_STATE_PATH", str(rs_path))
+    monkeypatch.setenv("HELIANTHUS_LEGACY_INSTANCE_GUID_PATH", str(legacy_path))
+    monkeypatch.setenv("HELIANTHUS_MIGRATION_MARKER_PATH", str(marker_path))
+    original_open = builtins.open
+    runtime_modes: list[str] = []
+
+    def spy_open(file, mode="r", *args, **kwargs):
+        if str(file).startswith(str(rs_path)):
+            runtime_modes.append(mode)
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", spy_open)
+    rc = module.main([])
     assert rc == module.EXIT_OK
-    assert rs_path.exists(), "case 3 must bootstrap runtime_state.json"
-    body = json.loads(rs_path.read_text())
-    assert body["schema_version"] == 1
-    assert "meta" in body and re.match(
-        module.INSTANCE_GUID_REGEX, body["meta"]["instance_guid"]
-    )
-    # Second run with the same paths must read the bootstrap file (case 1)
-    # rather than generate a new identity.
-    first_guid = body["meta"]["instance_guid"]
-    result2 = module.resolve_instance_guid(
-        runtime_state_path=str(rs_path), legacy_path=str(legacy_path)
-    )
-    assert result2.source == module.IDENTITY_SOURCE_RUNTIME_STATE, (
-        "after bootstrap persistence, restart must read runtime_state.json"
-    )
-    assert result2.guid == first_guid, (
-        "identity must remain stable across restarts after bootstrap"
-    )
+    output = capsys.readouterr().out.splitlines()
+    emitted = [line.split("=", 1)[1] for line in output if line.startswith("HELIANTHUS_INSTANCE_GUID=")]
+    assert len(emitted) == 1 and re.match(module.INSTANCE_GUID_REGEX, emitted[0])
+    assert not rs_path.exists(), "the wrapper must not create runtime_state.json"
+    assert runtime_modes and all(mode == "r" for mode in runtime_modes)
 
 
-def test_case1_does_not_overwrite_runtime_state(tmp_path: Path) -> None:
-    """When runtime_state.json already exists (case 1), main() must not
-    rewrite it — only the gateway owns ongoing writes. Bootstrap is a
-    case-3-only side effect."""
+def test_gateway_persisted_runtime_state_is_reused_without_regeneration(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Restart identity is supplied by gateway-persisted state, not fallback state."""
     module = _wrapper_module()
     rs_path = tmp_path / "runtime_state.json"
     legacy_path = tmp_path / "instance_guid"
     marker_path = tmp_path / "marker"
     _write_runtime_state(rs_path, guid=VALID_GUID_A)
     original_body = rs_path.read_text()
-    original_mtime = rs_path.stat().st_mtime_ns
-    monkey_env = {
-        "HELIANTHUS_RUNTIME_STATE_PATH": str(rs_path),
-        "HELIANTHUS_LEGACY_INSTANCE_GUID_PATH": str(legacy_path),
-        "HELIANTHUS_MIGRATION_MARKER_PATH": str(marker_path),
-    }
-    saved = {k: os.environ.get(k) for k in monkey_env}
-    os.environ.update(monkey_env)
-    try:
-        rc = module.main([])
-    finally:
-        for k, v in saved.items():
-            if v is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = v
+    monkeypatch.setenv("HELIANTHUS_RUNTIME_STATE_PATH", str(rs_path))
+    monkeypatch.setenv("HELIANTHUS_LEGACY_INSTANCE_GUID_PATH", str(legacy_path))
+    monkeypatch.setenv("HELIANTHUS_MIGRATION_MARKER_PATH", str(marker_path))
+    rc = module.main([])
     assert rc == module.EXIT_OK
-    # File untouched: bytes + mtime unchanged.
-    assert rs_path.read_text() == original_body, (
-        "case 1 (valid runtime_state) must not be overwritten by the wrapper"
-    )
-    assert rs_path.stat().st_mtime_ns == original_mtime, (
-        "case 1 must not rewrite the file (mtime preserved)"
-    )
+    assert rs_path.read_text() == original_body
+    output = capsys.readouterr().out
+    assert f"HELIANTHUS_INSTANCE_GUID={VALID_GUID_A}" in output
+    assert "HELIANTHUS_INSTANCE_GUID_SOURCE=runtime_state" in output
+
+
+def test_migration_halt_never_mutates_runtime_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Legacy-only failure may write its marker, never runtime state."""
+    module = _wrapper_module()
+    rs_path = tmp_path / "runtime_state.json"
+    legacy_path = tmp_path / "instance_guid"
+    marker_path = tmp_path / "marker"
+    legacy_path.write_text(VALID_GUID_A + "\n")
+    monkeypatch.setenv("HELIANTHUS_RUNTIME_STATE_PATH", str(rs_path))
+    monkeypatch.setenv("HELIANTHUS_LEGACY_INSTANCE_GUID_PATH", str(legacy_path))
+    monkeypatch.setenv("HELIANTHUS_MIGRATION_MARKER_PATH", str(marker_path))
+    original_open = builtins.open
+    runtime_modes: list[str] = []
+
+    def spy_open(file, mode="r", *args, **kwargs):
+        if str(file).startswith(str(rs_path)):
+            runtime_modes.append(mode)
+        return original_open(file, mode, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", spy_open)
+    assert module.main([]) == module.EXIT_MIGRATION_REQUIRED
+    assert not rs_path.exists()
+    assert runtime_modes and all(mode == "r" for mode in runtime_modes)
+    assert marker_path.exists(), "the separate migration marker remains required"
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Closes #237.

The fresh-install wrapper previously created `/data/runtime_state.json` before the gateway, violating the accepted sole-writer boundary and using weaker crash durability. This change removes the wrapper bootstrap writer. A fresh UUIDv4 is passed once to the gateway for eager persistence, existing gateway-persisted state remains authoritative, migration-required marker/token/exit behavior is preserved, and startup fails closed when the packaged gateway lacks `-instance-guid`.

Validation on exact HEAD `7c7347b52d5e1dc1aba15e6cede7beddd7c6eee4`:

- affected wrapper coverage: 35 passed;
- runtime-state wrapper suite: 23 passed;
- `python3 scripts/check_source_addr_wrapper.py`: PASS;
- complete standalone `./scripts/ci_local.sh`: PASS, including JSON/shell/terminology, smoke-doc, eeBUS, Modbus, Fronius, parity, rollout and private-address gates. The Fronius stage has its existing single declared skip.
- the initial hosted workflow exposed a stale assertion that required wrapper bootstrap persistence; follow-up `7c7347b` now asserts the runtime-state file remains absent and the exact hosted step passes locally.

Documentation is already satisfied by the accepted `helianthus-docs-ebus` runtime-state contract. Transport and physical smoke are not applicable; deterministic offline startup smoke passed. Live HA identity and bus assertions remain INT-20, and execution-plans #27 remains open.

Merge remains blocked until hosted checks pass, all feedback is reconciled, and a fresh independent exact-HEAD review returns `NO_BLOCKING_FINDINGS`.
